### PR TITLE
updating next-gen docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,11 @@ frontend: build_bootstrap
 install: build_bootstrap
 	$(call docker_run,make -f install.mk, -w all)
 	@echo Populating namespace within: $(USPARK_NAMESPACEROOTDIR)...
+	@if [ -d $(USPARK_NAMESPACEROOTDIR) ]; then \
+		echo "$(USPARK_NAMESPACEROOTDIR) already exists. "; \
+		echo "Stopping before removing $(USPARK_NAMESPACEROOTDIR)"; \
+		exit 1; \
+	fi
 	rm -rf $(USPARK_NAMESPACEROOTDIR)
 	mkdir -p $(USPARK_NAMESPACEROOTDIR)
 	mkdir -p $(USPARK_NAMESPACEROOTDIR)/docs

--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,11 @@ install: build_bootstrap
 	@echo Populating namespace within: $(USPARK_NAMESPACEROOTDIR)...
 	@if [ -d $(USPARK_NAMESPACEROOTDIR) ]; then \
 		echo "$(USPARK_NAMESPACEROOTDIR) already exists. "; \
-		echo "Stopping before removing $(USPARK_NAMESPACEROOTDIR)"; \
-		exit 1; \
+		read -p "Would you like to continue (rm -rf $(USPARK_NAMESPACEROOTDIR)) [y/N]? " action; \
+		if [ "$$action" = "y" ] && [ "$$action" = "Y" ]; then \
+			echo "Please remove $(USPARK_NAMESPACEROOTDIR) (e.g., rm -rf $(USPARK_NAMESPACEROOTDIR)) in order to allow installation"; \
+			exit 1; \
+		fi; \
 	fi
 	rm -rf $(USPARK_NAMESPACEROOTDIR)
 	mkdir -p $(USPARK_NAMESPACEROOTDIR)

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ install: build_bootstrap
 	@if [ -d $(USPARK_NAMESPACEROOTDIR) ]; then \
 		echo "$(USPARK_NAMESPACEROOTDIR) already exists. "; \
 		read -p "Would you like to continue (rm -rf $(USPARK_NAMESPACEROOTDIR)) [y/N]? " action; \
-		if [ "$$action" = "y" ] && [ "$$action" = "Y" ]; then \
+		if [ "$$action" != "y" ] && [ "$$action" != "Y" ]; then \
 			echo "Please remove $(USPARK_NAMESPACEROOTDIR) (e.g., rm -rf $(USPARK_NAMESPACEROOTDIR)) in order to allow installation"; \
 			exit 1; \
 		fi; \

--- a/build-trusses/build-x86_64.Dockerfile
+++ b/build-trusses/build-x86_64.Dockerfile
@@ -16,7 +16,7 @@ RUN sudo apk update &&\
     sudo chown root:root /etc/sudoers.d/docker &&\
     sudo sed -i.bak 's/^Defaults.*requiretty//g' /etc/sudoers
 
-USER docker
+#USER docker
 WORKDIR "/home/docker"
 
 # install git

--- a/build-trusses/build-x86_64.Dockerfile
+++ b/build-trusses/build-x86_64.Dockerfile
@@ -16,7 +16,8 @@ RUN sudo apk update &&\
     sudo chown root:root /etc/sudoers.d/docker &&\
     sudo sed -i.bak 's/^Defaults.*requiretty//g' /etc/sudoers
 
-#USER docker
+# Switch to USER docker (from USER opam), currently commented out due to UID conflicts with apline distros. Creating permissions issues.
+# USER docker 
 WORKDIR "/home/docker"
 
 # install git

--- a/docs/nextgen-toolkit/genuser-guide/install.rst
+++ b/docs/nextgen-toolkit/genuser-guide/install.rst
@@ -6,8 +6,16 @@ Building and Installing |uspark|
 Building |uspark| Tools
 ------------------------
 
-You will need to build the |uspark| toolchain before performing any other task.
-To achieve this, you need to issue the following command while in the top-level directory of 
+You will need to build the |uspark| toolchain before performing any other
+task.
+
+
+.. note:: The |uspark| toolchain requires approximately 2.4 GB of disk space.
+
+	  
+	  
+To achieve this, you need to issue the following command while in the
+top-level directory of 
 the |uspark| source-tree (the directory where the file RELEASE is located):
 
 
@@ -15,12 +23,13 @@ the |uspark| source-tree (the directory where the file RELEASE is located):
 
     make
 
-This will generate the required build truss to build the toolkit and documentation, 
-build the toolkit binaries, and additionally build the ``.html`` version of the documentation.
+This will generate the required build truss to build the toolkit and
+documentation, build the toolkit binaries, and additionally build the
+``.html`` version of the documentation.
 
-.. note:: If you are re-building the tools after a prior build, you can perform a cleanup by
-          issuing the command: ``make clean`` before issuing the 
-          command ``make`` as above.
+.. note:: If you are re-building the tools after a prior build, you can
+	  perform a cleanup by issuing the command: ``make clean`` before
+	  issuing the command ``make`` as above.
 
 
 

--- a/docs/sw-requirements.rst
+++ b/docs/sw-requirements.rst
@@ -83,6 +83,7 @@ After the opam environment switch, install the following opam packages in order:
     opam install menhir.20170712
     opam install ocamlgraph.1.8.8
     opam install ocamlfind.1.7.3
+    eval `opam config env`
  
 
 Coq Proof Assistant 
@@ -94,13 +95,13 @@ You need to install the Coq Proof Assistant via opam as shown below:
 ::
 
     opam install coq.8.6.1
-
+    eval `opam config env`
 
 CompCert Certified Compiler 
 ---------------------------
 
 The CompCert compiler is used to compile the C code for verified uberobjects within 
-|uspark|. The Compcert version currently supported is v3.0.1 and can be installed 
+|uspark|. The Compcert version currently supported is v3.1 and can be installed 
 as shown below:
 
 ::


### PR DESCRIPTION
Updates:
1.  To allow build on Ubuntu VM, removing USER docker from Dockerfile.
2. adding comment about tool size to documentation 
3. adding check to see if about to remove existing directory (unable to add user option to continue kept receiving errors when running nested bash if loops inside Makefile). 
4. Minor change to current-gen documentation to match version in text to version in code listing