### PR TITLE
Feature/auto rootdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,10 @@ export USPARK_INSTALLPREPDIR = $(USPARK_SRCROOTDIR)/_install
 
 ROOT_DIR ?= ~
 export USPARK_NAMESPACEROOTDIR := $(ROOT_DIR)/uberspark
+
+###### installation folders
 export USPARK_INSTALL_BINDIR := /usr/bin
+export USPARK_INSTALL_CONFIGDIR := /etc/uberspark
 
 export SUDO := sudo
 
@@ -126,6 +129,10 @@ install: build_bootstrap
 	cp -Rf $(USPARK_INSTALLPREPDIR)/staging/* $(USPARK_NAMESPACEROOTDIR)/staging/default/uberspark 
 	ln -sf $(USPARK_NAMESPACEROOTDIR)/staging/default $(USPARK_NAMESPACEROOTDIR)/staging/current
 	@echo Populated install namespace successfully
+	@echo Installing global configuration to $(USPARK_INSTALL_CONFIGDIR)...
+	@echo Note: You may need to enter your sudo password. 
+	$(SUDO) mkdir -p $(USPARK_INSTALL_CONFIGDIR)
+	@echo Wrote global configuration.
 	@echo Installing binary to $(USPARK_INSTALL_BINDIR)...
 	@echo Note: You may need to enter your sudo password. 
 	$(SUDO) cp -f $(USPARK_INSTALLPREPDIR)/bin/uberspark $(USPARK_INSTALL_BINDIR)/uberspark

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ export SYS_PROC_VERSION := $(shell cat /proc/version)
 define USPARK_CONFIG_CONTENTS 
 {
 	"uberspark-manifest":{
-		"manifest_node_types" : [ "uberspark-installconfig" ],
+		"manifest_node_types" : [ "uberspark-installation" ],
 		"uberspark_min_version" : "$(USPARK_VERSION)",
 		"uberspark_max_version" : "$(USPARK_VERSION)"
 	},
 
-    "uberspark-installconfig" : {
+    "uberspark-installation" : {
 		"rootDirectory" : "$(ROOT_DIR)"
 	}
 }

--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,24 @@
 
 ###### paths
 
+###### configuration variables that are inputs to the top-level build process
+ROOT_DIR ?= ~
+export USPARK_INSTALL_BINDIR := /usr/bin
+export USPARK_INSTALL_CONFIGDIR := /etc/uberspark
+export USPARK_VERSION := 6.0.0
+export USPARK_MANIFEST_FILENAME := uberspark.json
+
+
+
+###### automatic configuration variables
 export USPARK_SRCROOTDIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 export USPARK_BUILDTRUSSESDIR := $(USPARK_SRCROOTDIR)/build-trusses
 export USPARK_SRCDIR = $(USPARK_SRCROOTDIR)/src-nextgen
 export USPARK_DOCSDIR = $(USPARK_SRCROOTDIR)/docs
 export USPARK_INSTALLPREPDIR = $(USPARK_SRCROOTDIR)/_install
-
-ROOT_DIR ?= ~
 export USPARK_NAMESPACEROOTDIR := $(ROOT_DIR)/uberspark
 
-###### installation folders
-export USPARK_INSTALL_BINDIR := /usr/bin
-export USPARK_INSTALL_CONFIGDIR := /etc/uberspark
+
 
 export SUDO := sudo
 

--- a/docs/nextgen-toolkit/cossdev-guide/prepnamespace.rst
+++ b/docs/nextgen-toolkit/cossdev-guide/prepnamespace.rst
@@ -36,25 +36,11 @@ verification tools.
 |uberspark| staging environments can be created using the :ref:`frontend-cli-intro` as shown below:
 
 
-..  note::  In the following listings, we assume |uberspark| is installed
-            within a WSL/Ubuntu development environment. Accordingly we use the
-            ``--root-dir=/c/workspace/uberspark`` command-line option,  assuming |uberspark| was installed
-            at: ``/c/workspace/uberspark`` within WSL. You need to replace this with the appropriate
-            directory where |uberspark| is installed based on your development environment.
-            See |genuser-guide-ref|:::ref:`genuser-guide-install-installinguberspark`
-            for more details.
-
-..  note::  You can also omit the ``--root-dir`` argument altogether if uberspark is installed to 
-            the default location (``~/uberspark``) within your development environment (e.g., Ubuntu Linux).
-            See |genuser-guide-ref|:::ref:`genuser-guide-install-installinguberspark` for more details.
-
-
-
 .. highlight:: bash
 
 ::
 
-    uberspark staging create generic-platform --root-dir=/c/workspace/uberspark
+    uberspark staging create generic-platform
 
 
 With the aforementioned command, we create (and automatically switch to) a staging 
@@ -68,9 +54,9 @@ are required to build the  ``hello-mul`` |uobjcoll|.
 
 ::
 
-    uberspark staging config-set --setting-name=bridge_cc_bridge --setting-value=container/amd64/x86_32/generic/gcc/v5.4.0 --root-dir=/c/workspace/uberspark
-    uberspark staging config-set --setting-name=bridge_as_bridge --setting-value=container/amd64/x86_32/generic/gnu-as/v2.26.1 --root-dir=/c/workspace/uberspark
-    uberspark staging config-set --setting-name=bridge_ld_bridge --setting-value=container/amd64/x86_32/generic/gnu-ld/v2.26.1 --root-dir=/c/workspace/uberspark
+    uberspark staging config-set --setting-name=bridge_cc_bridge --setting-value=container/amd64/x86_32/generic/gcc/v5.4.0
+    uberspark staging config-set --setting-name=bridge_as_bridge --setting-value=container/amd64/x86_32/generic/gnu-as/v2.26.1
+    uberspark staging config-set --setting-name=bridge_ld_bridge --setting-value=container/amd64/x86_32/generic/gnu-ld/v2.26.1
 
 
 The aforementioned commands will set the staging compiler bridge to use GCC v5.4.0, assembler bridge to use 

--- a/src-nextgen/tools/frontend/commonopts.ml
+++ b/src-nextgen/tools/frontend/commonopts.ml
@@ -22,7 +22,8 @@ let handler_opts
 
   match rootdir with
   | None -> 
-    l_rootdir := Unix.getenv "HOME";
+    (*l_rootdir := Unix.getenv "HOME";*)
+    l_rootdir := "";
   | Some l_str ->
     l_rootdir := l_str;
   ;

--- a/src-nextgen/tools/frontend/uberspark_frontend.ml
+++ b/src-nextgen/tools/frontend/uberspark_frontend.ml
@@ -268,7 +268,7 @@ let cmd_default =
 	`S Manpage.s_exit_status;
   ] in
   Term.(ret (const (fun _ -> `Help (`Pager, None)) $ Commonopts.opts_t)),
-  Term.info "uberspark" ~version:"5.1" ~doc ~sdocs ~exits ~man
+  Term.info "uberspark" ~version:"6.0.0" ~doc ~sdocs ~exits ~man
 
 (* additional commands *)	
 let cmd_additions = [cmd_uobj; cmd_uobjcoll; cmd_staging; cmd_bridges]

--- a/src-nextgen/tools/libs/uberspark_manifest.ml.cppo
+++ b/src-nextgen/tools/libs/uberspark_manifest.ml.cppo
@@ -328,6 +328,11 @@ module Config = struct
 end
 
 
+module Installation = struct
+	#include "uberspark_manifest_installation.ml"
+end
+
+
 module Sentinel = struct
 	#include "uberspark_manifest_sentinel.ml"
 end

--- a/src-nextgen/tools/libs/uberspark_manifest.mli
+++ b/src-nextgen/tools/libs/uberspark_manifest.mli
@@ -165,6 +165,23 @@ module Config : sig
 end
 
 
+
+module Installation : sig
+
+  (****************************************************************************)
+  (* manifest node types *)
+  (****************************************************************************)
+
+  type json_node_uberspark_installation_t =
+  {
+    mutable f_rootDirectory : string;
+  }
+
+  val json_node_uberspark_installation_to_var : Yojson.Basic.t -> json_node_uberspark_installation_t -> bool
+
+end
+
+
 module Sentinel : sig
 
 

--- a/src-nextgen/tools/libs/uberspark_manifest_installation.ml
+++ b/src-nextgen/tools/libs/uberspark_manifest_installation.ml
@@ -1,0 +1,61 @@
+(*===========================================================================*)
+(*===========================================================================*)
+(* uberSpark installation manifest interface implementation *)
+(*	 author: amit vasudevan (amitvasudevan@acm.org) *)
+(*===========================================================================*)
+(*===========================================================================*)
+
+
+(*---------------------------------------------------------------------------*)
+(*---------------------------------------------------------------------------*)
+(* type definitions *)
+(*---------------------------------------------------------------------------*)
+(*---------------------------------------------------------------------------*)
+
+
+type json_node_uberspark_installation_t =
+{
+	mutable f_rootDirectory : string;
+};;
+
+
+(*---------------------------------------------------------------------------*)
+(*---------------------------------------------------------------------------*)
+(* interface definitions *)
+(*---------------------------------------------------------------------------*)
+(*---------------------------------------------------------------------------*)
+
+
+(*--------------------------------------------------------------------------*)
+(* convert json node "uberspark-installation" into json_node_uberspark_installation_t variable *)
+(* return: *)
+(* on success: true; json_node_uberspark_installation fields are modified with parsed values *)
+(* on failure: false; json_node_uberspark_installation fields are untouched *)
+(*--------------------------------------------------------------------------*)
+
+let json_node_uberspark_installation_to_var 
+	(mf_json : Yojson.Basic.t)
+	(json_node_uberspark_installation_var : json_node_uberspark_installation_t) 
+	: bool =
+	let retval = ref false in
+
+	try
+		let open Yojson.Basic.Util in
+			let json_node_uberspark_installation = mf_json |> member Uberspark_namespace.namespace_installation_mf_node_type_tag in
+		
+			if(json_node_uberspark_installation <> `Null) then
+				begin
+
+					json_node_uberspark_installation_var.f_rootDirectory <- json_node_uberspark_installation |> member "rootDirectory" |> to_string;
+					retval := true;
+				end
+			;
+
+	with Yojson.Basic.Util.Type_error _ -> 
+			retval := false;
+	;
+
+	(!retval)
+;;
+
+

--- a/src-nextgen/tools/libs/uberspark_namespace.ml
+++ b/src-nextgen/tools/libs/uberspark_namespace.ml
@@ -29,6 +29,7 @@ let namespace_root_mf_node_type_tag = "uberspark-manifest";;
 
 
 (* installation *)
+let namespace_installation_configdir = "/etc/uberspark";;
 let namespace_installation_mf_node_type_tag = "uberspark-installation";;
 
 

--- a/src-nextgen/tools/libs/uberspark_namespace.ml
+++ b/src-nextgen/tools/libs/uberspark_namespace.ml
@@ -28,6 +28,11 @@ let namespace_root_mf_filename = "uberspark.json";;
 let namespace_root_mf_node_type_tag = "uberspark-manifest";;
 
 
+(* installation *)
+let namespace_installation_mf_node_type_tag = "uberspark-installation";;
+
+
+
 (* uobjs *)
 let namespace_uobj = "uobjs";;
 let namespace_uobj_build_dir = "_build";;

--- a/src-nextgen/tools/libs/uberspark_namespace.mli
+++ b/src-nextgen/tools/libs/uberspark_namespace.mli
@@ -27,6 +27,7 @@ val namespace_root_mf_node_type_tag : string
 
 
 (* installation *)
+val namespace_installation_configdir : string
 val namespace_installation_mf_node_type_tag : string
 
 

--- a/src-nextgen/tools/libs/uberspark_namespace.mli
+++ b/src-nextgen/tools/libs/uberspark_namespace.mli
@@ -25,6 +25,11 @@ val namespace_root_dir_prefix : string ref
 val namespace_root_mf_filename : string
 val namespace_root_mf_node_type_tag : string
 
+
+(* installation *)
+val namespace_installation_mf_node_type_tag : string
+
+
 (* uobjs *)
 val namespace_uobj : string
 val namespace_uobj_build_dir : string


### PR DESCRIPTION
feature(tools/frontend): remove requirement of specifying --root-dir for WSL development environments
feature(tools/libs): add manifest parsing logic for uberspark installation configuration manifest
docs(dev-guide): revise developer documentation to reflect now optional --root-dir CLI parameter within WSL development environments
build(common): change top-level Makefile to create installation configuration within /etc/uberspark
