### PR TITLE
Feature ccbridge cclib

### DIFF
--- a/docs/nextgen-toolkit/cossdev-guide/create-uobjs.rst
+++ b/docs/nextgen-toolkit/cossdev-guide/create-uobjs.rst
@@ -6,7 +6,12 @@ Create |uobjs|
 ==============
 
 Creating |uobjs| that become part of a given |uobjcoll|, is facilitated by creating 
-a |uberspark| manifest file, |ubersparkmff|, within each |uobj| source folder.
+a |uberspark| manifest file, |ubersparkmff|, within each |uobj| source folder and 
+organizing and refactoring relevant sources that comprise the corresponding |uobjs|.
+
+
+Create |uobj| Manifest
+----------------------
 
 In our running example, the ``hello-mul`` |uobjcoll| that we want to create consists of
 a single ``main`` |uobj| housed within the folder:
@@ -47,9 +52,66 @@ Assembly source files (``asm-files``), and CASM (``casm-files``).
 the function ``main`` within the C source file ``main.c`` with return value ``uint32_t``, parameters
 ``(uint32_t multiplicand, uint32_t multiplier)``, followed by the number of positional parameters (``2`` in our case).
 
+
+Specify |uobj| callees
+----------------------
+
 ..  note::  ``uberspark-uobj`` *intrauobjcoll-callees*, *interuobjcoll-callees*,  and *legacy-callees* 
             node declarations are still work-in-progress and can be  omitted for discussion for the time being
 
+
+Specify |uobj| Additional Sections
+----------------------------------
+
+A |uobj| binary consists of certain pre-defined sections corresponding to the |uobj| code, data and stack.
+However, if you require variables or functions within the |uobj| to be added to a special section (e.g., 
+for specific padding or memory alignment purposes) you can qualify it within the sources (e.g., via
+__attribute__((section()))) and specify it within the `sections` sub-node of
+the `uberspark-uobj` manifest node.
+
+
+For example, consider the |uobj| C code below, that defines a variable `special` which needs to be output to a special
+section that is aligned on a page-boundary and padded to a page size. 
+
+.. code-block:: c
+   :linenos:
+
+   __attribute__((section(".specialsec"))) unsigned char special[512];
+
+The following is a snippet of the `uberspark-uobj` manifest node specification for the |uobj| that specifies this
+output section for the |uobj| binary.
+
+.. code-block:: json
+   :linenos:
+
+   {
+    	"uberspark-uobj" : {
+         "sections": [
+            {
+               "name" : "specialsec",
+               "output_names" : [ ".specialsec" ],
+               "type" : "0x0",
+               "prot" : "0x0",
+               "size" : "0x1000",
+               "aligned_at" : "0x1000",
+               "pad_to" : "0x1000"
+            }
+         ]
+      }
+   }
+
+
+A similar approach can be used to place |uobj| function definitions within a desired output section in 
+the |uobj| binary.
+
+..  note::  You can have multiple comma delimited output section definitions within the manifest. 
+            See |reference-manifest-ref|:::ref:`reference-manifest-uberspark-uobj` for further details on 
+            the `sections` sub-node list definition within the `uberspark-uobj` manifest node.
+            
+
+
+Organize |uobj| Sources
+-----------------------
 
 After declararing the |uobj| via the manifest, the next step is to move over the relevant sources as
 specified within the manifest and add the ``uberspark`` header definitions. 

--- a/docs/nextgen-toolkit/cossdev-guide/create-uobjs.rst
+++ b/docs/nextgen-toolkit/cossdev-guide/create-uobjs.rst
@@ -60,18 +60,21 @@ Specify |uobj| callees
             node declarations are still work-in-progress and can be  omitted for discussion for the time being
 
 
-Specify |uobj| Additional Sections
-----------------------------------
+Specify |uobj| Sections
+-----------------------
 
-A |uobj| binary consists of certain pre-defined sections corresponding to the |uobj| code, data and stack.
-However, if you require variables or functions within the |uobj| to be added to a special section (e.g., 
-for specific padding or memory alignment purposes) you can qualify it within the sources (e.g., via
-__attribute__((section()))) and specify it within the `sections` sub-node of
+The `section` sub-node of the `uberspark-uobj` manifest node is used to specify |uobj|
+binary sectioning parameters. Such parameters include the section size, alignment and 
+padding.
+
+A |uobj| binary consists of certain standard sections corresponding to the |uobj| code, data and stack.
+In addition, variables or functions within the |uobj| can be added to special developer-defined sections (e.g., 
+for specific padding or memory alignment purposes). Such develper-defined section definitions are appropriately
+qualified within the sources (e.g., via __attribute__((section()))) and specified using the `sections` sub-node of
 the `uberspark-uobj` manifest node.
 
-
 For example, consider the |uobj| C code below, that defines a variable `special` which needs to be output to a special
-section that is aligned on a page-boundary and padded to a page size. 
+section that spans a page in size at maximum, is aligned on a page-boundary, and is padded to a page size. 
 
 .. code-block:: c
    :linenos:
@@ -89,10 +92,8 @@ output section for the |uobj| binary.
          "sections": [
             {
                "name" : "specialsec",
-               "output_names" : [ ".specialsec" ],
-               "type" : "0x0",
-               "prot" : "0x0",
                "size" : "0x1000",
+               "output_names" : [ ".specialsec" ],
                "aligned_at" : "0x1000",
                "pad_to" : "0x1000"
             }
@@ -100,13 +101,44 @@ output section for the |uobj| binary.
       }
    }
 
-
 A similar approach can be used to place |uobj| function definitions within a desired output section in 
 the |uobj| binary.
 
+The `section` sub-node can also be used to specify section sizes, alignment and padding of pre-defined
+|uobj| binary sections such as code, data and stack. 
+
+As an example, the following is a snippet of the `uberspark-uobj` manifest node specification for 
+the |uobj| that specifies the maximum size of the |uobj| code section (in bytes).
+
+.. code-block:: json
+   :linenos:
+
+   {
+    	"uberspark-uobj" : {
+         "sections": [
+            {
+               "name" : "uobj_code",
+               "size" : "0x1000"
+            }
+         ]
+      }
+   }
+
+..  warning:: specifying a section size that is smaller than the actual |uobj| generated section
+              size will result in a |uobj| build error.
+
+..  note::  `uobj_code` is the name allocated to the standard |uobj| code section. 
+            See |reference-manifest-ref|:::ref:`reference-manifest-uberspark-uobj` for further details on 
+            standar |uobj| section names.
+
+..  note::  *name* and *size* are required fields within the `sections` sub-node for all |uobj| section definitions.
+            For developer-defined sections, the *output_names* field is an additional requirement.
+            See |reference-manifest-ref|:::ref:`reference-manifest-uberspark-uobj` for further details on 
+            the `sections` sub-node field definitions
+
 ..  note::  You can have multiple comma delimited output section definitions within the manifest. 
             See |reference-manifest-ref|:::ref:`reference-manifest-uberspark-uobj` for further details on 
-            the `sections` sub-node list definition within the `uberspark-uobj` manifest node.
+            the `sections` sub-node list definition options within the `uberspark-uobj` manifest node.
             
 
 

--- a/docs/nextgen-toolkit/reference/manifest.rst
+++ b/docs/nextgen-toolkit/reference/manifest.rst
@@ -530,7 +530,7 @@ The JSON declaration of the ``uberspark-uobj`` node is as below:
 
     :property name: name of the |uobj| section 
     :proptype name: string 
-    :options type: "uobj_code", "uobj_data", "uobj_dmadata", "uobj_ustack", "uobj_tstack", "<developer-defined>" where 
+    :options type: "uobj_code", "uobj_rodata", "uobj_rwdata", "uobj_dmadata", "uobj_ustack", "uobj_tstack", "<developer-defined>" where 
                    <developer-defined> is a developer defined section name
 
     :property size: hexadecimal size (in bytes) of the section 

--- a/docs/nextgen-toolkit/reference/manifest.rst
+++ b/docs/nextgen-toolkit/reference/manifest.rst
@@ -493,10 +493,10 @@ The JSON declaration of the ``uberspark-uobj`` node is as below:
     :proptype legacy-callees: string list
 
 
-    :property uobjrtl: |uobj| runtime library definition sub-node 
+    :property uobjrtl: comma delimited list of |uobj| runtime library definition sub-nodes
     :proptype uobjrtl: :json:object:`uobjrtl` list
 
-    :property sections: |uobj| additional sections definition sub-node 
+    :property sections: comma delimited list of |uobj| additional sections definition sub-nodes
     :proptype sections: :json:object:`sections` list
 
 

--- a/docs/nextgen-toolkit/reference/manifest.rst
+++ b/docs/nextgen-toolkit/reference/manifest.rst
@@ -409,6 +409,8 @@ bridge. The JSON declaration of the ``uberspark-bridge-ld`` node is as below:
    :property params_prefix_output: command line option prefix to specify output file name
    :proptype params_prefix_output: string
 
+   :property cmd_generate_flat_binary: command prefix to generate a flat-form binary. note that the input and output file will be added to this automatically
+   :proptype cmd_generate_flat_binary: string
 
 An example definition of the ``uberspark-bridge-ld`` node for the GNU ld linker, within |ubersparkmff| follows:
 
@@ -439,14 +441,18 @@ An example definition of the ``uberspark-bridge-ld`` node for the GNU ld linker,
             "params_prefix_lscript" : "-T",
             "params_prefix_libdir" : "-L",
             "params_prefix_lib" : "-l",
-            "params_prefix_output" : "-o"
+            "params_prefix_output" : "-o",
+
+    		"cmd_generate_flat_binary" : "arm-linux-gnueabihf-objcopy -O binary"
+
         }
     }
 
 
 .. note::   Here the Linker bridge type is defined to be a container and ``uberspark_bridges.Dockerfile``
             is the container dockerfile that includes the build for running GNU ld within an ``amd64`` 
-            environment (e.g., ubuntu or alpine) and producing a 32-bit ELF binary
+            environment (e.g., ubuntu or alpine) and producing a 32-bit ELF binary. It also uses the 
+            `objcopy` tool to generate flat-form binary image.
 
 
 .. _reference-manifest-uberspark-uobj:

--- a/docs/nextgen-toolkit/reference/manifest.rst
+++ b/docs/nextgen-toolkit/reference/manifest.rst
@@ -337,6 +337,9 @@ bridge. The JSON declaration of the ``uberspark-bridge-cc`` node is as below:
    :property params_prefix_include: command line option prefix to include a header file
    :proptype params_prefix_include: string
 
+   :property params_cclib: full pathname to compiler runtime library (e.g., libgcc.a)
+   :proptype params_cclib: string
+
 An example definition of the ``uberspark-bridge-cc`` node for the GNU gcc C compiler, within |ubersparkmff| follows:
 
 
@@ -366,8 +369,9 @@ An example definition of the ``uberspark-bridge-cc`` node for the GNU gcc C comp
             "params_prefix_obj" : "-c",
             "params_prefix_asm" : "-S",
             "params_prefix_output" : "-o",
-            "params_prefix_include" : "-I"
-        }
+            "params_prefix_include" : "-I",
+            "params_cclib" : "/usr/lib/gcc/x86_64-linux-gnu/5/libgcc.a"
+       }
     }
 
 
@@ -492,6 +496,9 @@ The JSON declaration of the ``uberspark-uobj`` node is as below:
     :property uobjrtl: |uobj| runtime library definition sub-node 
     :proptype uobjrtl: :json:object:`uobjrtl` list
 
+    :property sections: |uobj| additional sections definition sub-node 
+    :proptype sections: :json:object:`sections` list
+
 
 .. json:object:: sources
 
@@ -513,7 +520,30 @@ The JSON declaration of the ``uberspark-uobj`` node is as below:
     :property namespace: namespace of the |uobj| runtime library
     :proptype namespace: string 
 
+.. json:object:: sections
 
+    :property name: name of the |uobj| section 
+    :proptype name: string 
+
+    :property output_names: comma delimited list of |uobj| output section names (e.g., defined via __attribute__((section())) ) 
+    :proptype output_names: string list 
+
+    :property type: hexadecimal type of the section 
+    :proptype type: string 
+    :options type: "0x0"
+
+    :property prot: hexadecimal protection of the section 
+    :proptype prot: string 
+    :options prot: "0x0"
+
+    :property size: hexadecimal size (in bytes) of the section 
+    :proptype size: string 
+
+    :property aligned_at: hexadecimal alignment (in bytes) of the section 
+    :proptype aligned_at: string 
+
+    :property pad_to: hexadecimal padding boundary (in bytes) of the section 
+    :proptype pad_to: string 
 
 An example definition of the ``uberspark-uobj`` node for a sample |uobj| called ``add``, within |ubersparkmff| follows:
 
@@ -576,9 +606,19 @@ An example definition of the ``uberspark-uobj`` node for a sample |uobj| called 
 			    {
 				    "namespace" : "uberspark/uobjrtl/crypto"
 			    }
-    		]
+    		],
 
-    
+    		"sections": [
+                {
+                    "name" : "example_additional_section",
+                    "output_names" : [ ".exaddsec" ],
+                    "type" : "0x0",
+                    "prot" : "0x0",
+                    "size" : "0x200000",
+                    "aligned_at" : "0x1000",
+                    "pad_to" : "0x1000"
+                }
+            ]
         }
     }
 

--- a/docs/nextgen-toolkit/reference/manifest.rst
+++ b/docs/nextgen-toolkit/reference/manifest.rst
@@ -502,7 +502,7 @@ The JSON declaration of the ``uberspark-uobj`` node is as below:
     :property uobjrtl: comma delimited list of |uobj| runtime library definition sub-nodes
     :proptype uobjrtl: :json:object:`uobjrtl` list
 
-    :property sections: comma delimited list of |uobj| additional sections definition sub-nodes
+    :property sections: (optional) comma delimited list of |uobj| additional sections definition sub-nodes
     :proptype sections: :json:object:`sections` list
 
 
@@ -530,25 +530,29 @@ The JSON declaration of the ``uberspark-uobj`` node is as below:
 
     :property name: name of the |uobj| section 
     :proptype name: string 
-
-    :property output_names: comma delimited list of |uobj| output section names (e.g., defined via __attribute__((section())) ) 
-    :proptype output_names: string list 
-
-    :property type: hexadecimal type of the section 
-    :proptype type: string 
-    :options type: "0x0"
-
-    :property prot: hexadecimal protection of the section 
-    :proptype prot: string 
-    :options prot: "0x0"
+    :options type: "uobj_code", "uobj_data", "uobj_dmadata", "uobj_ustack", "uobj_tstack", "<developer-defined>" where 
+                   <developer-defined> is a developer defined section name
 
     :property size: hexadecimal size (in bytes) of the section 
     :proptype size: string 
 
-    :property aligned_at: hexadecimal alignment (in bytes) of the section 
+    :property output_names: comma delimited list of |uobj| output section names for developer-defined 
+                            sections (e.g., defined via __attribute__((section())) ). This field is optional for 
+                            standard |uobj| sections (e.g., uobj_code).
+    :proptype output_names: string list 
+
+    :property type: (optional) hexadecimal type of the section 
+    :proptype type: string 
+    :options type: "0x0"
+
+    :property prot: (optional) hexadecimal protection of the section 
+    :proptype prot: string 
+    :options prot: "0x0"
+
+    :property aligned_at: (optional) hexadecimal alignment (in bytes) of the section 
     :proptype aligned_at: string 
 
-    :property pad_to: hexadecimal padding boundary (in bytes) of the section 
+    :property pad_to: (optional) hexadecimal padding boundary (in bytes) of the section 
     :proptype pad_to: string 
 
 An example definition of the ``uberspark-uobj`` node for a sample |uobj| called ``add``, within |ubersparkmff| follows:

--- a/src-nextgen/bridges/as-bridge/container/amd64/armv8_32/generic/gnu-as/default/uberspark.json
+++ b/src-nextgen/bridges/as-bridge/container/amd64/armv8_32/generic/gnu-as/default/uberspark.json
@@ -21,7 +21,11 @@
 			"cpu" : "generic",
 			"version" : "v2.26.1",
 			"path" : ".",
-			"params" : [],
+			"params" : [
+				"-marm",
+				"-march=armv8-a",
+				"-mno-thumb-interwork"
+			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 

--- a/src-nextgen/bridges/as-bridge/container/amd64/armv8_32/generic/gnu-as/v2.26.1/uberspark.json
+++ b/src-nextgen/bridges/as-bridge/container/amd64/armv8_32/generic/gnu-as/v2.26.1/uberspark.json
@@ -21,7 +21,11 @@
 			"cpu" : "generic",
 			"version" : "v2.26.1",
 			"path" : ".",
-			"params" : ["-mcpu=cortex-a53"],
+			"params" : [
+				"-marm",
+				"-march=armv8-a",
+				"-mno-thumb-interwork"
+			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 

--- a/src-nextgen/bridges/as-bridge/container/amd64/armv8_32/generic/gnu-as/v2.26.1/uberspark.json
+++ b/src-nextgen/bridges/as-bridge/container/amd64/armv8_32/generic/gnu-as/v2.26.1/uberspark.json
@@ -15,13 +15,13 @@
 		"bridge-hdr":{
 			"btype" : "container",
 			"bname" : "gnu-as",
-			"execname" : "gcc",
+			"execname" : "arm-linux-gnueabihf-gcc",
 			"devenv" : "amd64",
 			"arch" : "armv8_32",
 			"cpu" : "generic",
 			"version" : "v2.26.1",
 			"path" : ".",
-			"params" : [],
+			"params" : ["-mcpu=cortex-a53"],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/default/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/default/uberspark.json
@@ -21,14 +21,21 @@
 			"cpu" : "generic",
 			"version" : "v5.4.0",
 			"path" : ".",
-			"params" : [],
+		    "params" : [
+			    "-nostdinc",
+			    "-nostdlib",
+           	    "-nostartfiles",
+				"-ffreestanding"
+			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
 		"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : "/usr/lib/gcc-cross/arm-linux-gnueabihf/5/libgcc.a"
+
 	}
 
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/default/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/default/uberspark.json
@@ -25,7 +25,10 @@
 			    "-nostdinc",
 			    "-nostdlib",
            	    "-nostartfiles",
-				"-ffreestanding"
+				"-ffreestanding",
+				"-marm",
+				"-march=armv8-a",
+				"-mno-thumb-interwork"
 			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},

--- a/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v4.9.3/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v4.9.3/uberspark.json
@@ -15,17 +15,21 @@
 		"bridge-hdr":{
 			"btype" : "container",
 			"bname" : "gcc",
-			"execname" : "gcc",
+			"execname" : "arm-linux-gnueabihf-gcc-4.9",
 			"devenv" : "amd64",
 			"arch" : "armv8_32",
 			"cpu" : "generic",
 			"version" : "v4.9.3",
 			"path" : ".",
-			"params" : [],
+		        "params" : [
+			    "-nostdinc",
+                 	    "-nostartfiles",
+			    "-mcpu=cortex-a53"
+			    ],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
-		"params_prefix_obj" : "-c",
+	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
         "params_prefix_include" : "-I"

--- a/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v4.9.3/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v4.9.3/uberspark.json
@@ -23,8 +23,10 @@
 			"path" : ".",
 		        "params" : [
 			    "-nostdinc",
+			    "-nostdlib",
                  	    "-nostartfiles",
-			    "-mcpu=cortex-a53"
+			    "-mcpu=cortex-a53",
+			    "-ffreestanding"
 			    ],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},

--- a/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v4.9.3/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v4.9.3/uberspark.json
@@ -26,7 +26,9 @@
 			    "-nostdlib",
            	    "-nostartfiles",
 				"-ffreestanding",
-				"-mcpu=cortex-a53"
+				"-marm",
+				"-march=armv8-a",
+				"-mno-thumb-interwork"
 			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},

--- a/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v4.9.3/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v4.9.3/uberspark.json
@@ -21,20 +21,21 @@
 			"cpu" : "generic",
 			"version" : "v4.9.3",
 			"path" : ".",
-		        "params" : [
+		    "params" : [
 			    "-nostdinc",
 			    "-nostdlib",
-                 	    "-nostartfiles",
-			    "-mcpu=cortex-a53",
-			    "-ffreestanding"
-			    ],
+           	    "-nostartfiles",
+				"-ffreestanding",
+				"-mcpu=cortex-a53"
+			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
 	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : "/usr/lib/gcc-cross/arm-linux-gnueabihf/4.9/libgcc.a"
 	}
 
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v5.4.0/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v5.4.0/uberspark.json
@@ -21,18 +21,22 @@
 			"cpu" : "generic",
 			"version" : "v5.4.0",
 			"path" : ".",
- 		        "params" : [
-			    "-nostdinc",
-			    "-nostartfiles",
-			    "-mcpu=cortex-a53"
-			    ],
+	        "params" : [
+				"-nostdinc",
+				"-nostdlib",
+				"-nostartfiles",
+				"-ffreestanding",
+				"-mcpu=cortex-a53"
+			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
 	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : "/usr/lib/gcc-cross/arm-linux-gnueabihf/5/libgcc.a"
+
 	}
 
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v5.4.0/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v5.4.0/uberspark.json
@@ -15,17 +15,21 @@
 		"bridge-hdr":{
 			"btype" : "container",
 			"bname" : "gcc",
-			"execname" : "gcc",
+			"execname" : "arm-linux-gnueabihf-gcc",
 			"devenv" : "amd64",
 			"arch" : "armv8_32",
 			"cpu" : "generic",
 			"version" : "v5.4.0",
 			"path" : ".",
-			"params" : [],
+ 		        "params" : [
+			    "-nostdinc",
+			    "-nostartfiles",
+			    "-mcpu=cortex-a53"
+			    ],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
-		"params_prefix_obj" : "-c",
+	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
         "params_prefix_include" : "-I"

--- a/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v5.4.0/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/armv8_32/generic/gcc/v5.4.0/uberspark.json
@@ -26,7 +26,9 @@
 				"-nostdlib",
 				"-nostartfiles",
 				"-ffreestanding",
-				"-mcpu=cortex-a53"
+				"-marm",
+				"-march=armv8-a",
+				"-mno-thumb-interwork"
 			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/uberspark.json
@@ -28,7 +28,9 @@
 	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : ""
+
 	}
 
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark.json
@@ -28,7 +28,9 @@
 	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : ""
+
 	}
 
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/uberspark.json
@@ -28,7 +28,9 @@
 	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : ""
+
 	}
 
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/uberspark.json
@@ -28,7 +28,9 @@
 	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : ""
+
 	}
 
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/uberspark.json
@@ -28,7 +28,9 @@
 	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : ""
+
 	}
 
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/uberspark.json
@@ -28,7 +28,9 @@
 	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : ""
+
 	}
 
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/uberspark.json
@@ -28,7 +28,9 @@
 	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : ""
+
 	}
 
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/gcc/default/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/gcc/default/uberspark.json
@@ -21,14 +21,22 @@
 			"cpu" : "generic",
 			"version" : "v5.4.0",
 			"path" : ".",
-			"params" : [ "-m32" ],
+			"params" : [ 
+				"-nostdinc",
+			    "-nostdlib",
+           	    "-nostartfiles",
+				"-ffreestanding",
+				"-m32" 
+			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
 		"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : "/usr/lib/gcc/x86_64-linux-gnu/5/libgcc.a"
+
 	}
 
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/gcc/v5.4.0/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/gcc/v5.4.0/uberspark.json
@@ -21,14 +21,22 @@
 			"cpu" : "generic",
 			"version" : "v5.4.0",
 			"path" : ".",
-			"params" : [ "-m32" ],
+			"params" : [ 
+				"-nostdinc",
+			    "-nostdlib",
+           	    "-nostartfiles",
+				"-ffreestanding",
+				"-m32" 
+			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
 		"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : "/usr/lib/gcc/x86_64-linux-gnu/5/libgcc.a"
+
 	}
 
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/gcc/v5.5.0/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/gcc/v5.5.0/uberspark.json
@@ -21,14 +21,22 @@
 			"cpu" : "generic",
 			"version" : "v5.5.0",
 			"path" : ".",
-			"params" : [ "-m32" ],
+			"params" : [ 
+				"-nostdinc",
+			    "-nostdlib",
+           	    "-nostartfiles",
+				"-ffreestanding",
+				"-m32" 
+			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
 		"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
-        "params_prefix_include" : "-I"
+		"params_prefix_include" : "-I",
+		"params_cclib" : "/usr/lib/gcc/x86_64-linux-gnu/5/libgcc.a"
+
 	}
 
 }

--- a/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/default/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/default/uberspark-bridge.Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Amit Vasudevan <amitvasudevan@acm.org>, Matt McCormack <matthe
 RUN apt-get update &&\
     apt-get -yqq install gcc-arm-linux-gnueabihf \
     	    	 	 gcc-multilib-arm-linux-gnueabihf \
-			 binutils-arm-linux-gnueabihf &&\
+			 binutils-arm-linux-gnueabihf && \
     apt-get clean && rm -rf /var/lib/apt/lists/* 
 
 

--- a/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/default/uberspark.json
+++ b/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/default/uberspark.json
@@ -28,7 +28,9 @@
 		"params_prefix_lscript" : "-T",
 		"params_prefix_libdir" : "-L",
 		"params_prefix_lib" : "-l",
-		"params_prefix_output" : "-o"
+		"params_prefix_output" : "-o",
+
+		"cmd_generate_flat_binary" : "arm-linux-gnueabihf-objcopy -O binary"
 
 	}
 

--- a/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/v2.26.1/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/v2.26.1/uberspark-bridge.Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Amit Vasudevan <amitvasudevan@acm.org>, Matt McCormack <matthe
 RUN apt-get update &&\
     apt-get -yqq install gcc-arm-linux-gnueabihf \
     	    	 	 gcc-multilib-arm-linux-gnueabihf \
-			 binutils-arm-linux-gnueabihf &&\
+			 binutils-arm-linux-gnueabihf && \
     apt-get clean && rm -rf /var/lib/apt/lists/* 
 
 

--- a/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/v2.26.1/uberspark.json
+++ b/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/v2.26.1/uberspark.json
@@ -29,7 +29,9 @@
 		"params_prefix_lscript" : "-T",
 		"params_prefix_libdir" : "-L",
 		"params_prefix_lib" : "-l",
-		"params_prefix_output" : "-o"
+		"params_prefix_output" : "-o",
+
+		"cmd_generate_flat_binary" : "arm-linux-gnueabihf-objcopy -O binary"
 
 	}
 

--- a/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/v2.26.1/uberspark.json
+++ b/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/v2.26.1/uberspark.json
@@ -15,13 +15,16 @@
 		"bridge-hdr":{
 			"btype" : "container",
 			"bname" : "gnu-ld",
-			"execname" : "ld",
+			"execname" : "arm-linux-gnueabihf-ld",
 			"devenv" : "amd64",
 			"arch" : "armv8_32",
 			"cpu" : "generic",
 			"version" : "v2.26.1",
 			"path" : ".",
-			"params" : [],
+		        "params" : [
+			    "-nostdinc",
+			    "-nostartfiles"
+			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 

--- a/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/v2.26.1/uberspark.json
+++ b/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/v2.26.1/uberspark.json
@@ -23,6 +23,7 @@
 			"path" : ".",
 		        "params" : [
 			    "-nostdinc",
+			    "-nostdlib",
 			    "-nostartfiles"
 			],
 			"container_fname" : "uberspark_bridges.Dockerfile"

--- a/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/v2.26.1/uberspark.json
+++ b/src-nextgen/bridges/ld-bridge/container/amd64/armv8_32/generic/gnu-ld/v2.26.1/uberspark.json
@@ -22,9 +22,6 @@
 			"version" : "v2.26.1",
 			"path" : ".",
 		        "params" : [
-			    "-nostdinc",
-			    "-nostdlib",
-			    "-nostartfiles"
 			],
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},

--- a/src-nextgen/bridges/ld-bridge/container/amd64/x86_32/generic/gnu-ld/default/uberspark.json
+++ b/src-nextgen/bridges/ld-bridge/container/amd64/x86_32/generic/gnu-ld/default/uberspark.json
@@ -28,7 +28,9 @@
 		"params_prefix_lscript" : "-T",
 		"params_prefix_libdir" : "-L",
 		"params_prefix_lib" : "-l",
-		"params_prefix_output" : "-o"
+		"params_prefix_output" : "-o",
+
+		"cmd_generate_flat_binary" : "arm-linux-gnueabihf-objcopy -O binary"
 
 	}
 

--- a/src-nextgen/bridges/ld-bridge/container/amd64/x86_32/generic/gnu-ld/v2.26.1/uberspark.json
+++ b/src-nextgen/bridges/ld-bridge/container/amd64/x86_32/generic/gnu-ld/v2.26.1/uberspark.json
@@ -28,7 +28,9 @@
 		"params_prefix_lscript" : "-T",
 		"params_prefix_libdir" : "-L",
 		"params_prefix_lib" : "-l",
-		"params_prefix_output" : "-o"
+		"params_prefix_output" : "-o",
+
+		"cmd_generate_flat_binary" : "arm-linux-gnueabihf-objcopy -O binary"
 
 	}
 

--- a/src-nextgen/include/uberspark.h
+++ b/src-nextgen/include/uberspark.h
@@ -50,6 +50,7 @@
 #ifndef __UBERSPARK_H__
 #define __UBERSPARK_H__
 
+#ifndef __ASSEMBLY__
 
 #include <uberspark/uobjrtl/crt/include/stdint.h>
 #include <uberspark/uobjrtl/crt/include/stdbool.h>
@@ -57,6 +58,7 @@
 #include <uberspark/uobjrtl/crt/include/stdarg.h>
 #include <uberspark/uobjrtl/crt/include/string.h>
 
+#endif
 
 #include <uberspark/include/basedefs.h>
 

--- a/src-nextgen/include/uberspark.h
+++ b/src-nextgen/include/uberspark.h
@@ -55,6 +55,7 @@
 #include <uberspark/uobjrtl/crt/include/stdbool.h>
 #include <uberspark/uobjrtl/crt/include/stddef.h>
 #include <uberspark/uobjrtl/crt/include/stdarg.h>
+#include <uberspark/uobjrtl/crt/include/string.h>
 
 
 #include <uberspark/include/basedefs.h>

--- a/src-nextgen/include/uberspark.h
+++ b/src-nextgen/include/uberspark.h
@@ -50,10 +50,12 @@
 #ifndef __UBERSPARK_H__
 #define __UBERSPARK_H__
 
-#include <stdint.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdarg.h>
+
+#include <uberspark/uobjrtl/crt/include/stdint.h>
+#include <uberspark/uobjrtl/crt/include/stdbool.h>
+#include <uberspark/uobjrtl/crt/include/stddef.h>
+#include <uberspark/uobjrtl/crt/include/stdarg.h>
+
 
 #include <uberspark/include/basedefs.h>
 

--- a/src-nextgen/sentinels/cpu/armv8_32/generic/hyp/interuobjcoll/call/uberspark.json
+++ b/src-nextgen/sentinels/cpu/armv8_32/generic/hyp/interuobjcoll/call/uberspark.json
@@ -26,8 +26,8 @@
         PUBLICMETHOD_ADDR = address of public method within uobj/uobjcoll
         */ 
         "code": "
-            ldr r0, = PUBLICMETHOD_ADDR
-            mov pc, r0
+            ldr r3, = PUBLICMETHOD_ADDR
+            mov pc, r3
         ",
 
         /*  sentinel library code template 

--- a/src-nextgen/tools/libs/defs/basedefs.ml.us
+++ b/src-nextgen/tools/libs/defs/basedefs.ml.us
@@ -7,14 +7,14 @@
 		(* from usbinformat.h *)
 		type usbinformat_section_info_t =
 			{
-				f_type         : int;			
-				f_prot         : int;			
-				f_size         : int;
-        f_aligned_at   : int;
-	      f_pad_to       : int;
-				f_addr_start   : int;
-				f_addr_file    : int;
-        f_reserved     : int; 
+				mutable f_type         : int;			
+				mutable f_prot         : int;			
+				mutable f_size         : int;
+        		mutable f_aligned_at   : int;
+	      		mutable f_pad_to       : int;
+				mutable f_addr_start   : int;
+				mutable f_addr_file    : int;
+        		mutable f_reserved     : int; 
 			};;
 
 
@@ -29,9 +29,9 @@
 
 		type section_info_t = 
 			{
-				f_name: string;
-				f_subsection_list : string list;
-				usbinformat : usbinformat_section_info_t;
+				mutable f_name: string;
+				mutable f_subsection_list : string list;
+				mutable usbinformat : usbinformat_section_info_t;
 			};;
 
 			

--- a/src-nextgen/tools/libs/defs/basedefs.mli.us
+++ b/src-nextgen/tools/libs/defs/basedefs.mli.us
@@ -1,12 +1,12 @@
 type usbinformat_section_info_t = {
-  f_type : int;
-  f_prot : int;
-  f_size : int;
-  f_aligned_at : int;
-  f_pad_to : int;
-  f_addr_start : int;
-  f_addr_file : int;
-  f_reserved : int;
+  mutable f_type : int;
+  mutable f_prot : int;
+  mutable f_size : int;
+  mutable f_aligned_at : int;
+  mutable f_pad_to : int;
+  mutable f_addr_start : int;
+  mutable f_addr_file : int;
+  mutable f_reserved : int;
 }
 type target_def_t = {
   mutable f_platform : string;
@@ -14,9 +14,9 @@ type target_def_t = {
   mutable f_cpu : string;
 }
 type section_info_t = {
-  f_name : string;
-  f_subsection_list : string list;
-  usbinformat : usbinformat_section_info_t;
+  mutable f_name : string;
+  mutable f_subsection_list : string list;
+  mutable usbinformat : usbinformat_section_info_t;
 }
 type uobjcoll_sentineltypes_t = { s_type : string; s_type_id : string; }
 type uobjcoll_exitcallee_t = {

--- a/src-nextgen/tools/libs/uberspark_bridge.mli
+++ b/src-nextgen/tools/libs/uberspark_bridge.mli
@@ -116,6 +116,7 @@ module Ld : sig
 		string list ->
 		string list ->
 		string list ->
+		string list ->
 		string ->
 		bool
 

--- a/src-nextgen/tools/libs/uberspark_bridge.mli
+++ b/src-nextgen/tools/libs/uberspark_bridge.mli
@@ -113,6 +113,7 @@ module Ld : sig
 		?context_path_builddir : string -> 
 		string ->
 		string ->
+		string ->
 		string list ->
 		string list ->
 		string list ->

--- a/src-nextgen/tools/libs/uberspark_bridge_as.ml
+++ b/src-nextgen/tools/libs/uberspark_bridge_as.ml
@@ -237,6 +237,9 @@ let invoke
 				add_d_cmd := !add_d_cmd ^ param ^ " ";
 			) json_node_uberspark_bridge_as_var.json_node_bridge_hdr_var.params;
 
+			(* add assembly definition since we are working with assembly files *)
+			add_d_cmd := !add_d_cmd ^ " " ^ "-D__ASSEMBLY__" ^ " ";
+
 			(* add includes *)
 			add_d_cmd := !add_d_cmd ^ " " ^ !as_includes ^ " ";
 

--- a/src-nextgen/tools/libs/uberspark_bridge_cc.ml
+++ b/src-nextgen/tools/libs/uberspark_bridge_cc.ml
@@ -264,7 +264,9 @@ let invoke
 	end done;
 
 	(* as a final step add command to copy compiler cclib file if any into the current build context *)
-	d_cmd := !d_cmd ^ " && " ^ "cp -f " ^ json_node_uberspark_bridge_cc_var.params_cclib ^ " /root/src/cclib.a";
+	d_cmd := !d_cmd ^ " && " ^ "cp -f " ^ json_node_uberspark_bridge_cc_var.params_cclib ^ 
+				" " ^ Uberspark_namespace.namespace_bridge_container_build_mountpath ^ "/" ^
+				Uberspark_namespace.namespace_uobj_cclib_filename;
 
 	Uberspark_logger.log ~lvl:Uberspark_logger.Debug "d_cmd=%s" !d_cmd;
 

--- a/src-nextgen/tools/libs/uberspark_bridge_cc.ml
+++ b/src-nextgen/tools/libs/uberspark_bridge_cc.ml
@@ -40,6 +40,7 @@ let json_node_uberspark_bridge_cc_var: Uberspark_manifest.Bridge.Cc.json_node_ub
 	params_prefix_asm = "";
 	params_prefix_output = "";
 	params_prefix_include = "";
+	params_cclib = "";
 };;
 
 

--- a/src-nextgen/tools/libs/uberspark_bridge_cc.ml
+++ b/src-nextgen/tools/libs/uberspark_bridge_cc.ml
@@ -263,6 +263,9 @@ let invoke
 		
 	end done;
 
+	(* as a final step add command to copy compiler cclib file if any into the current build context *)
+	d_cmd := !d_cmd ^ " && " ^ "cp -f " ^ json_node_uberspark_bridge_cc_var.params_cclib ^ " /root/src/cclib.a";
+
 	Uberspark_logger.log ~lvl:Uberspark_logger.Debug "d_cmd=%s" !d_cmd;
 
 	(* construct bridge namespace *)

--- a/src-nextgen/tools/libs/uberspark_bridge_container.ml
+++ b/src-nextgen/tools/libs/uberspark_bridge_container.ml
@@ -73,6 +73,7 @@ let run_image
             cmdline := !cmdline @ [ "/bin/sh" ];
             cmdline := !cmdline @ [ "-c" ];
             cmdline := !cmdline @ [ r_d_cmd ];
+            
 
             let (r_exitcode, r_signal, _) = Uberspark_osservices.exec_process_withlog 
                     ~stag:"docker" "docker" !cmdline in

--- a/src-nextgen/tools/libs/uberspark_bridge_ld.ml
+++ b/src-nextgen/tools/libs/uberspark_bridge_ld.ml
@@ -229,6 +229,11 @@ let invoke
 	(* add linker script option and filename*)
  	d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_lscript ^ " " ^ lscript_filename;
 
+
+	(* add linker output format *)
+ 	(*d_cmd := !d_cmd ^ " " ^ "--oformat=elf32-littlearm";*)
+ 	(*d_cmd := !d_cmd ^ " " ^ "--oformat=binary";*)
+
 	(* add output filename *)
 	d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_output ^ " " ^ output_filename;
 
@@ -246,6 +251,11 @@ let invoke
 	List.iter (fun lib_abs_filename -> 
 		d_cmd := !d_cmd ^ " " ^ lib_abs_filename;
 	) lib_abs_list;
+
+	(* add binary output generation command; TBD: bring in via ld-bridge manifest *)
+ 	d_cmd := !d_cmd ^ " " ^ " && " ^ "arm-linux-gnueabihf-objcopy -O binary " ^ output_filename ^ " " ^
+	 		(output_filename ^ ".obin");
+
 
 	(* construct bridge namespace *)
 	let bridge_ns = Uberspark_namespace.namespace_bridge_ld_bridge ^ "/" ^

--- a/src-nextgen/tools/libs/uberspark_bridge_ld.ml
+++ b/src-nextgen/tools/libs/uberspark_bridge_ld.ml
@@ -258,8 +258,6 @@ let invoke
 
 
 	Uberspark_logger.log ~lvl:Uberspark_logger.Debug "d_cmd=%s" !d_cmd;
-	Uberspark_logger.log ~lvl:Uberspark_logger.Debug "bridge_ns=%s" bridge_ns;
-
 
 	(* invoke the linker *)
 	if json_node_uberspark_bridge_ld_var.json_node_bridge_hdr_var.btype = "container" then begin

--- a/src-nextgen/tools/libs/uberspark_bridge_ld.ml
+++ b/src-nextgen/tools/libs/uberspark_bridge_ld.ml
@@ -40,6 +40,7 @@ let json_node_uberspark_bridge_ld_var: Uberspark_manifest.Bridge.Ld.json_node_ub
 	params_prefix_libdir = "";
 	params_prefix_lib = "";
 	params_prefix_output = "";
+	cmd_generate_flat_binary = "";
 };;
 
 
@@ -229,11 +230,6 @@ let invoke
 	(* add linker script option and filename*)
  	d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_lscript ^ " " ^ lscript_filename;
 
-
-	(* add linker output format *)
- 	(*d_cmd := !d_cmd ^ " " ^ "--oformat=elf32-littlearm";*)
- 	(*d_cmd := !d_cmd ^ " " ^ "--oformat=binary";*)
-
 	(* add output filename *)
 	d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_output ^ " " ^ output_filename;
 
@@ -252,9 +248,9 @@ let invoke
 		d_cmd := !d_cmd ^ " " ^ lib_abs_filename;
 	) lib_abs_list;
 
-	(* add binary output generation command; TBD: bring in via ld-bridge manifest *)
- 	d_cmd := !d_cmd ^ " " ^ " && " ^ "arm-linux-gnueabihf-objcopy -O binary " ^ output_filename ^ " " ^
-	 		(output_filename ^ ".obin");
+	(* add flat binary output generation command *)
+ 	d_cmd := !d_cmd ^ " " ^ " && " ^ json_node_uberspark_bridge_ld_var.cmd_generate_flat_binary ^ " "  ^
+	 		output_filename ^ " " ^	(output_filename ^ ".obin");
 
 
 	(* construct bridge namespace *)

--- a/src-nextgen/tools/libs/uberspark_bridge_ld.ml
+++ b/src-nextgen/tools/libs/uberspark_bridge_ld.ml
@@ -221,13 +221,16 @@ let invoke
 	) json_node_uberspark_bridge_ld_var.json_node_bridge_hdr_var.params;
 
 
-	(* add linker script option and filename*)
- 	d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_lscript ^ " " ^ lscript_filename;
-
 	(* iterate over object file list and include them into linker command line *)
 	List.iter (fun o_filename -> 
 		d_cmd := !d_cmd ^ " " ^ o_filename;
 	) o_file_list;
+
+	(* add linker script option and filename*)
+ 	d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_lscript ^ " " ^ lscript_filename;
+
+	(* add output filename *)
+	d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_output ^ " " ^ output_filename;
 
 	(* iterate over lib dir list and include them into linker command line *)
 	List.iter (fun lib_dir -> 
@@ -244,11 +247,6 @@ let invoke
 		d_cmd := !d_cmd ^ " " ^ lib_abs_filename;
 	) lib_abs_list;
 
-	(* add output filename *)
-	d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_output ^ " " ^ output_filename;
-
-	Uberspark_logger.log ~lvl:Uberspark_logger.Debug "d_cmd=%s" !d_cmd;
-
 	(* construct bridge namespace *)
 	let bridge_ns = Uberspark_namespace.namespace_bridge_ld_bridge ^ "/" ^
 		json_node_uberspark_bridge_ld_var.json_node_bridge_hdr_var.btype ^ "/" ^
@@ -257,6 +255,11 @@ let invoke
 		json_node_uberspark_bridge_ld_var.json_node_bridge_hdr_var.cpu ^ "/" ^
 		json_node_uberspark_bridge_ld_var.json_node_bridge_hdr_var.bname ^ "/" ^
 		json_node_uberspark_bridge_ld_var.json_node_bridge_hdr_var.version in
+
+
+	Uberspark_logger.log ~lvl:Uberspark_logger.Debug "d_cmd=%s" !d_cmd;
+	Uberspark_logger.log ~lvl:Uberspark_logger.Debug "bridge_ns=%s" bridge_ns;
+
 
 	(* invoke the linker *)
 	if json_node_uberspark_bridge_ld_var.json_node_bridge_hdr_var.btype = "container" then begin

--- a/src-nextgen/tools/libs/uberspark_bridge_ld.ml
+++ b/src-nextgen/tools/libs/uberspark_bridge_ld.ml
@@ -204,8 +204,9 @@ let invoke
 	(lscript_filename : string)
 	(output_filename : string)
 	(o_file_list : string list)
-	(lib_file_list : string list)
 	(lib_dir_list : string list)
+	(lib_file_list : string list)
+	(lib_abs_list : string list)
 	(context_path : string)
 	: bool =
 
@@ -237,6 +238,11 @@ let invoke
 	List.iter (fun lib_file -> 
 		d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_lib ^ lib_file;
 	) lib_file_list;
+
+	(* iterate over libraries provided with absolute pathnames *)
+	List.iter (fun lib_abs_filename -> 
+		d_cmd := !d_cmd ^ " " ^ lib_abs_filename;
+	) lib_abs_list;
 
 	(* add output filename *)
 	d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_output ^ " " ^ output_filename;

--- a/src-nextgen/tools/libs/uberspark_bridge_ld.ml
+++ b/src-nextgen/tools/libs/uberspark_bridge_ld.ml
@@ -203,7 +203,8 @@ let build
 let invoke 
 	?(context_path_builddir = ".")
 	(lscript_filename : string)
-	(output_filename : string)
+	(binary_filename : string)
+	(binary_flat_filename : string)
 	(o_file_list : string list)
 	(lib_dir_list : string list)
 	(lib_file_list : string list)
@@ -231,7 +232,7 @@ let invoke
  	d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_lscript ^ " " ^ lscript_filename;
 
 	(* add output filename *)
-	d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_output ^ " " ^ output_filename;
+	d_cmd := !d_cmd ^ " " ^ json_node_uberspark_bridge_ld_var.params_prefix_output ^ " " ^ binary_filename;
 
 	(* iterate over lib dir list and include them into linker command line *)
 	List.iter (fun lib_dir -> 
@@ -250,7 +251,7 @@ let invoke
 
 	(* add flat binary output generation command *)
  	d_cmd := !d_cmd ^ " " ^ " && " ^ json_node_uberspark_bridge_ld_var.cmd_generate_flat_binary ^ " "  ^
-	 		output_filename ^ " " ^	(output_filename ^ ".obin");
+	 		binary_filename ^ " " ^ binary_flat_filename;
 
 
 	(* construct bridge namespace *)

--- a/src-nextgen/tools/libs/uberspark_codegen_uobjcoll.ml
+++ b/src-nextgen/tools/libs/uberspark_codegen_uobjcoll.ml
@@ -154,8 +154,8 @@ let generate_uobj_binary_image_section_mapping
             
             List.iter ( fun (uobjinfo_entry : Defs.Basedefs.uobjinfo_t) ->
                 Printf.fprintf oc "\n";
-                Printf.fprintf oc "\n.section .uobj_%s" uobjinfo_entry.f_uobj_name;
-                Printf.fprintf oc "\n.incbin \"%s\"" ("./" ^ uobjinfo_entry.f_uobj_name ^ "/" ^ Uberspark_namespace.namespace_uobj_build_dir ^ "/uobj.bin");
+                Printf.fprintf oc "\n.section .section_uobj_%s" uobjinfo_entry.f_uobj_name;
+                Printf.fprintf oc "\n.incbin \"%s\"" ("./" ^ uobjinfo_entry.f_uobj_name ^ "/" ^ Uberspark_namespace.namespace_uobj_build_dir ^ "/uobj.bin.obin");
                 Printf.fprintf oc "\n";
             ) uobjcoll_uobjinfo_list;
 

--- a/src-nextgen/tools/libs/uberspark_codegen_uobjcoll.ml
+++ b/src-nextgen/tools/libs/uberspark_codegen_uobjcoll.ml
@@ -155,7 +155,7 @@ let generate_uobj_binary_image_section_mapping
             List.iter ( fun (uobjinfo_entry : Defs.Basedefs.uobjinfo_t) ->
                 Printf.fprintf oc "\n";
                 Printf.fprintf oc "\n.section .section_uobj_%s" uobjinfo_entry.f_uobj_name;
-                Printf.fprintf oc "\n.incbin \"%s\"" ("./" ^ uobjinfo_entry.f_uobj_name ^ "/" ^ Uberspark_namespace.namespace_uobj_build_dir ^ "/uobj.bin.obin");
+                Printf.fprintf oc "\n.incbin \"%s\"" ("./" ^ uobjinfo_entry.f_uobj_name ^ "/" ^ Uberspark_namespace.namespace_uobj_build_dir ^ "/" ^ Uberspark_namespace.namespace_uobj_binary_flat_image_filename);
                 Printf.fprintf oc "\n";
             ) uobjcoll_uobjinfo_list;
 

--- a/src-nextgen/tools/libs/uberspark_manifest.mli
+++ b/src-nextgen/tools/libs/uberspark_manifest.mli
@@ -105,6 +105,7 @@ module Bridge : sig
       mutable params_prefix_libdir: string;
       mutable params_prefix_lib: string;
       mutable params_prefix_output: string;
+      mutable cmd_generate_flat_binary: string;
     }
 
     val json_node_uberspark_bridge_ld_to_var : Yojson.Basic.t -> json_node_uberspark_bridge_ld_t -> bool

--- a/src-nextgen/tools/libs/uberspark_manifest.mli
+++ b/src-nextgen/tools/libs/uberspark_manifest.mli
@@ -89,6 +89,7 @@ module Bridge : sig
       mutable params_prefix_asm: string;
       mutable params_prefix_output: string;
       mutable params_prefix_include: string;
+      mutable params_cclib: string;
     }
 
     val json_node_uberspark_bridge_cc_to_var : Yojson.Basic.t -> json_node_uberspark_bridge_cc_t -> bool

--- a/src-nextgen/tools/libs/uberspark_manifest_bridge_cc.ml
+++ b/src-nextgen/tools/libs/uberspark_manifest_bridge_cc.ml
@@ -19,6 +19,7 @@ type json_node_uberspark_bridge_cc_t =
 	mutable params_prefix_asm: string;
 	mutable params_prefix_output: string;
 	mutable params_prefix_include: string;
+	mutable params_cclib : string;
 }
 ;;
 
@@ -56,6 +57,7 @@ let json_node_uberspark_bridge_cc_to_var
 						json_node_uberspark_bridge_cc_var.params_prefix_asm <- Yojson.Basic.Util.to_string (Yojson.Basic.Util.member "params_prefix_asm" json_node_uberspark_bridge_cc);
 						json_node_uberspark_bridge_cc_var.params_prefix_output <- Yojson.Basic.Util.to_string (Yojson.Basic.Util.member "params_prefix_output" json_node_uberspark_bridge_cc);
 						json_node_uberspark_bridge_cc_var.params_prefix_include <- Yojson.Basic.Util.to_string (Yojson.Basic.Util.member "params_prefix_include" json_node_uberspark_bridge_cc);
+						json_node_uberspark_bridge_cc_var.params_cclib <- Yojson.Basic.Util.to_string (Yojson.Basic.Util.member "params_cclib" json_node_uberspark_bridge_cc);
 
 						retval := true;
 					end;
@@ -88,6 +90,7 @@ let json_node_uberspark_bridge_cc_var_to_jsonstr
 	retstr := !retstr ^ Printf.sprintf  "\n\t\t\"params_prefix_asm\" : \"%s\"," json_node_uberspark_bridge_cc_var.params_prefix_asm;
 	retstr := !retstr ^ Printf.sprintf  "\n\t\t\"params_prefix_output\" : \"%s\"," json_node_uberspark_bridge_cc_var.params_prefix_output;
 	retstr := !retstr ^ Printf.sprintf  "\n\t\t\"params_prefix_include\" : \"%s\"" json_node_uberspark_bridge_cc_var.params_prefix_include;
+	retstr := !retstr ^ Printf.sprintf  "\n\t\t\"params_cclib\" : \"%s\"" json_node_uberspark_bridge_cc_var.params_cclib;
 
 	retstr := !retstr ^ Printf.sprintf  "\n\t}";
 	retstr := !retstr ^ Printf.sprintf  "\n";

--- a/src-nextgen/tools/libs/uberspark_manifest_bridge_ld.ml
+++ b/src-nextgen/tools/libs/uberspark_manifest_bridge_ld.ml
@@ -19,6 +19,7 @@ type json_node_uberspark_bridge_ld_t =
 	mutable params_prefix_libdir: string;
 	mutable params_prefix_lib: string;
 	mutable params_prefix_output: string;
+	mutable cmd_generate_flat_binary: string;
 }
 ;;
 
@@ -56,6 +57,7 @@ let json_node_uberspark_bridge_ld_to_var
 						json_node_uberspark_bridge_ld_var.params_prefix_libdir <- Yojson.Basic.Util.to_string (Yojson.Basic.Util.member "params_prefix_libdir" json_node_uberspark_bridge_ld);
 						json_node_uberspark_bridge_ld_var.params_prefix_lib <- Yojson.Basic.Util.to_string (Yojson.Basic.Util.member "params_prefix_lib" json_node_uberspark_bridge_ld);
 						json_node_uberspark_bridge_ld_var.params_prefix_output <- Yojson.Basic.Util.to_string (Yojson.Basic.Util.member "params_prefix_output" json_node_uberspark_bridge_ld);
+						json_node_uberspark_bridge_ld_var.cmd_generate_flat_binary <- Yojson.Basic.Util.to_string (Yojson.Basic.Util.member "cmd_generate_flat_binary" json_node_uberspark_bridge_ld);
 
 						retval := true;
 					end;
@@ -88,6 +90,7 @@ let json_node_uberspark_bridge_ld_var_to_jsonstr
 	retstr := !retstr ^ Printf.sprintf  "\n\t\t\"params_prefix_libdir\" : \"%s\"," json_node_uberspark_bridge_ld_var.params_prefix_libdir;
 	retstr := !retstr ^ Printf.sprintf  "\n\t\t\"params_prefix_lib\" : \"%s\"," json_node_uberspark_bridge_ld_var.params_prefix_lib;
 	retstr := !retstr ^ Printf.sprintf  "\n\t\t\"params_prefix_output\" : \"%s\"" json_node_uberspark_bridge_ld_var.params_prefix_output;
+	retstr := !retstr ^ Printf.sprintf  "\n\t\t\"cmd_generate_flat_binary\" : \"%s\"" json_node_uberspark_bridge_ld_var.cmd_generate_flat_binary;
 
 	retstr := !retstr ^ Printf.sprintf  "\n\t}";
 	retstr := !retstr ^ Printf.sprintf  "\n";

--- a/src-nextgen/tools/libs/uberspark_manifest_uobj.ml
+++ b/src-nextgen/tools/libs/uberspark_manifest_uobj.ml
@@ -354,7 +354,7 @@ let json_node_uberspark_uobj_sections_to_var
 								let section_entry : Defs.Basedefs.section_info_t = 
 								{ 
 									f_name = Yojson.Basic.Util.to_string (x |> member "name");	
-									f_subsection_list = [];	
+									f_subsection_list = json_list_to_string_list ( Yojson.Basic.Util.to_list (x |> member "output_names") );	
 									usbinformat = { f_type = int_of_string (Yojson.Basic.Util.to_string (x |> member "type")); 
 													f_prot = int_of_string (Yojson.Basic.Util.to_string (x |> member "prot")); 
 													f_size = int_of_string (Yojson.Basic.Util.to_string (x |> member "size"));

--- a/src-nextgen/tools/libs/uberspark_manifest_uobj.ml
+++ b/src-nextgen/tools/libs/uberspark_manifest_uobj.ml
@@ -353,18 +353,59 @@ let json_node_uberspark_uobj_sections_to_var
 							List.iter (fun x ->
 								let section_entry : Defs.Basedefs.section_info_t = 
 								{ 
-									f_name = Yojson.Basic.Util.to_string (x |> member "name");	
-									f_subsection_list = json_list_to_string_list ( Yojson.Basic.Util.to_list (x |> member "output_names") );	
-									usbinformat = { f_type = int_of_string (Yojson.Basic.Util.to_string (x |> member "type")); 
-													f_prot = int_of_string (Yojson.Basic.Util.to_string (x |> member "prot")); 
-													f_size = int_of_string (Yojson.Basic.Util.to_string (x |> member "size"));
-													f_aligned_at = int_of_string (Yojson.Basic.Util.to_string (x |> member "aligned_at")); 
-													f_pad_to = int_of_string (Yojson.Basic.Util.to_string (x |> member "pad_to")); 
+									f_name = "";	
+									f_subsection_list = [];	
+									usbinformat = { f_type = 0; 
+													f_prot = 0; 
+													f_size = 0;
+													f_aligned_at = 0; 
+													f_pad_to = 0; 
 													f_addr_start=0; 
 													f_addr_file = 0;
 													f_reserved = 0;
 													};
 								} in
+
+								(* required field *)
+								section_entry.f_name <- 
+									Yojson.Basic.Util.to_string (x |> member "name");	
+
+								(* required field *)
+								section_entry.usbinformat.f_size <- 
+									int_of_string (Yojson.Basic.Util.to_string (x |> member "size"));
+
+								(* 
+									this is required for developer defined sections, but we dont complain here
+									but allow the linking phase to complain if any references to this
+									section appear
+								*)
+								if (x |> member "output_names") != `Null then begin
+									section_entry.f_subsection_list <- 
+										json_list_to_string_list ( Yojson.Basic.Util.to_list (x |> member "output_names") );	
+								end;
+
+
+								(* the following fields are all optional *)
+								if (x |> member "type") != `Null then begin
+									section_entry.usbinformat.f_type <-
+										int_of_string (Yojson.Basic.Util.to_string (x |> member "type"));
+								end;
+
+								if (x |> member "prot") != `Null then begin
+									section_entry.usbinformat.f_prot <- 
+										int_of_string (Yojson.Basic.Util.to_string (x |> member "prot")); 
+								end;
+
+								if (x |> member "aligned_at") != `Null then begin
+									section_entry.usbinformat.f_aligned_at <- 
+										int_of_string (Yojson.Basic.Util.to_string (x |> member "aligned_at")); 
+								end;
+
+								if (x |> member "pad_to") != `Null then begin
+									section_entry.usbinformat.f_pad_to <- 
+										int_of_string (Yojson.Basic.Util.to_string (x |> member "pad_to")); 
+								end;
+
 
 								sections_assoc_list := !sections_assoc_list @ [ (section_entry.f_name, section_entry) ];
 												

--- a/src-nextgen/tools/libs/uberspark_namespace.ml
+++ b/src-nextgen/tools/libs/uberspark_namespace.ml
@@ -46,6 +46,7 @@ let namespace_uobj_linkerscript_filename = "uobj.lscript";;
 let namespace_uobj_binary_image_filename = "uobj.bin";;
 let namespace_uobj_top_level_include_header_src_filename = "uobj.h";;
 let namespace_uobj_mf_node_type_tag = "uberspark-uobj";;
+let namespace_uobj_cclib_filename = "cclib.a";;
 
 
 (* uobjcoll *)
@@ -90,6 +91,8 @@ let namespace_config_mf_node_type_tag = "uberspark-config";;
 (* bridges *)
 let namespace_bridge = "bridges";;
 let namespace_bridge_container_filename = "uberspark-bridge.Dockerfile";;
+let namespace_bridge_container_build_mountpath = "/root/src";;
+
 let namespace_bridge_cc_mf_node_type_tag = "uberspark-bridge-cc";;
 let namespace_bridge_ld_mf_node_type_tag = "uberspark-bridge-ld";;
 let namespace_bridge_as_mf_node_type_tag = "uberspark-bridge-as";;

--- a/src-nextgen/tools/libs/uberspark_namespace.ml
+++ b/src-nextgen/tools/libs/uberspark_namespace.ml
@@ -43,7 +43,8 @@ let namespace_uobj_intrauobjcoll_callees_info_src_filename = "uobj_intrauobjcoll
 let namespace_uobj_interuobjcoll_callees_info_src_filename = "uobj_interuobjcoll_callees_info.c";;
 let namespace_uobj_legacy_callees_info_src_filename = "uobj_legacy_callees_info.c";;
 let namespace_uobj_linkerscript_filename = "uobj.lscript";;
-let namespace_uobj_binary_image_filename = "uobj.bin";;
+let namespace_uobj_binary_image_filename = "uobj.exe";;
+let namespace_uobj_binary_flat_image_filename = "uobj.exe.flat";;
 let namespace_uobj_top_level_include_header_src_filename = "uobj.h";;
 let namespace_uobj_mf_node_type_tag = "uberspark-uobj";;
 let namespace_uobj_cclib_filename = "cclib.a";;
@@ -55,7 +56,8 @@ let namespace_uobjcoll_build_dir = "_build";;
 let namespace_uobjcoll_uobj_binary_image_section_mapping_src_filename = "uobjcoll_uobj_binsec_map.S";;
 let namespace_uobjcoll_sentinel_definitions_src_filename = "uobjcoll_sentinels.S";;
 let namespace_uobjcoll_linkerscript_filename = "uobjcoll.lscript";;
-let namespace_uobjcoll_binary_image_filename = "uobjcoll.bin";;
+let namespace_uobjcoll_binary_image_filename = "uobjcoll.exe";;
+let namespace_uobjcoll_binary_flat_image_filename = "uobjcoll.exe.flat";;
 
 (* legacy *)
 let namespace_legacy = "legacy";;

--- a/src-nextgen/tools/libs/uberspark_namespace.mli
+++ b/src-nextgen/tools/libs/uberspark_namespace.mli
@@ -43,6 +43,8 @@ val namespace_uobj_linkerscript_filename : string
 val namespace_uobj_binary_image_filename : string
 val namespace_uobj_top_level_include_header_src_filename : string
 val namespace_uobj_mf_node_type_tag : string
+val namespace_uobj_cclib_filename : string
+
 
 (* uobjcoll *)
 val namespace_uobjcoll : string
@@ -86,6 +88,7 @@ val namespace_config_mf_node_type_tag : string
 (* bridges *)
 val namespace_bridge : string
 val namespace_bridge_container_filename : string
+val namespace_bridge_container_build_mountpath : string
 val namespace_bridge_cc_mf_node_type_tag : string
 val namespace_bridge_ld_mf_node_type_tag : string
 val namespace_bridge_as_mf_node_type_tag : string

--- a/src-nextgen/tools/libs/uberspark_namespace.mli
+++ b/src-nextgen/tools/libs/uberspark_namespace.mli
@@ -41,6 +41,7 @@ val namespace_uobj_interuobjcoll_callees_info_src_filename : string
 val namespace_uobj_legacy_callees_info_src_filename : string
 val namespace_uobj_linkerscript_filename : string
 val namespace_uobj_binary_image_filename : string
+val namespace_uobj_binary_flat_image_filename : string
 val namespace_uobj_top_level_include_header_src_filename : string
 val namespace_uobj_mf_node_type_tag : string
 val namespace_uobj_cclib_filename : string
@@ -53,6 +54,7 @@ val namespace_uobjcoll_uobj_binary_image_section_mapping_src_filename : string
 val namespace_uobjcoll_sentinel_definitions_src_filename : string
 val namespace_uobjcoll_linkerscript_filename : string
 val namespace_uobjcoll_binary_image_filename : string
+val namespace_uobjcoll_binary_flat_image_filename : string
 
 (* legacy *)
 val namespace_legacy : string

--- a/src-nextgen/tools/libs/uberspark_uobj.ml
+++ b/src-nextgen/tools/libs/uberspark_uobj.ml
@@ -1271,6 +1271,7 @@ class uobject
 			 ~context_path_builddir:Uberspark_namespace.namespace_uobj_build_dir 
 			Uberspark_namespace.namespace_uobj_linkerscript_filename
 			Uberspark_namespace.namespace_uobj_binary_image_filename
+			Uberspark_namespace.namespace_uobj_binary_flat_image_filename
 			!o_file_list
 			[ ] [ ]	[ ("." ^ "/" ^ Uberspark_namespace.namespace_uobj_cclib_filename) ] ".";
 

--- a/src-nextgen/tools/libs/uberspark_uobj.ml
+++ b/src-nextgen/tools/libs/uberspark_uobj.ml
@@ -603,8 +603,7 @@ class uobject
 		()
 		: unit =
 		
-		let l_add_section (uobj_f_sections: (string * Defs.Basedefs.section_info_t) list)
-						(section_f_name: string)
+		let l_add_section (section_f_name: string)
 						(section_f_subsection_list : string list)
 						(section_usbinformat_f_type : int)
 						(section_usbinformat_f_prot : int)
@@ -629,12 +628,13 @@ class uobject
 
 			(* override size, alignment and padding info if specified in the manifest *)
 			(* also append any extra subsections if specified in the manifest *)
-			if (List.mem_assoc section_f_name uobj_f_sections) then begin
-				let l_var_sinfo_mf : Defs.Basedefs.section_info_t = (List.assoc section_f_name uobj_f_sections) in
+			if (List.mem_assoc section_f_name json_node_uberspark_uobj_var.f_sections) then begin
+				let l_var_sinfo_mf : Defs.Basedefs.section_info_t = (List.assoc section_f_name json_node_uberspark_uobj_var.f_sections) in
 				l_var_sinfo.usbinformat.f_size <- l_var_sinfo_mf.usbinformat.f_size;
 				l_var_sinfo.usbinformat.f_aligned_at <- l_var_sinfo_mf.usbinformat.f_aligned_at;
 				l_var_sinfo.usbinformat.f_pad_to <- l_var_sinfo_mf.usbinformat.f_pad_to;
 				l_var_sinfo.f_subsection_list <- l_var_sinfo.f_subsection_list @ l_var_sinfo_mf.f_subsection_list;
+				json_node_uberspark_uobj_var.f_sections <- List.remove_assoc section_f_name json_node_uberspark_uobj_var.f_sections;
 			end;
 
 			d_default_sections_list := !d_default_sections_list @ [ (section_f_name, l_var_sinfo) ];
@@ -643,8 +643,7 @@ class uobject
 		in
 
 		(* start with uobj state save area section *)
-		l_add_section json_node_uberspark_uobj_var.f_sections
-					"uobj_ssa" [ ".uobj_ssa" ] 
+		l_add_section "uobj_ssa" [ ".uobj_ssa" ] 
 					Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_SSA
 					0 
 					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
@@ -655,8 +654,7 @@ class uobject
 		Hashtbl.iter (fun (pm_name:string) (pm_info:Uberspark_manifest.Uobj.json_node_uberspark_uobj_publicmethods_t)  ->
 			let section_name = ("uobj_pm_" ^ pm_name) in 
 
-			l_add_section json_node_uberspark_uobj_var.f_sections
-						section_name [ "." ^ section_name ]
+			l_add_section section_name [ "." ^ section_name ]
 						Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_PMINFO
 						0 
 						Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
@@ -667,183 +665,95 @@ class uobject
 		
 
 		(* intrauobjcoll callees slt code section *)
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_intrauobjcoll_csltcode", {
-			f_name = "uobj_intrauobjcoll_csltcode";	
-			f_subsection_list = [ ".uobj_intrauobjcoll_csltcode" ];	
-			usbinformat = { f_type= Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_INTRAUOBJCOLL_CSLTCODE; 
-							f_prot=0; 
-							f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-							f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_addr_start=0; 
-							f_addr_file = 0;
-							f_reserved = 0;
-						};
-		}) ];
+		l_add_section "uobj_intrauobjcoll_csltcode" [ ".uobj_intrauobjcoll_csltcode" ]
+					Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_INTRAUOBJCOLL_CSLTCODE
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
 		(* intrauobjcoll callees slt data section *)
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_intrauobjcoll_csltdata", {
-			f_name = "uobj_intrauobjcoll_csltdata";	
-			f_subsection_list = [ ".uobj_intrauobjcoll_csltdata" ];	
-			usbinformat = { f_type= Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_INTRAUOBJCOLL_CSLTDATA; 
-							f_prot=0; 
-							f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-							f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_addr_start=0; 
-							f_addr_file = 0;
-							f_reserved = 0;
-						};
-		}) ];
-
+		l_add_section "uobj_intrauobjcoll_csltdata" [ ".uobj_intrauobjcoll_csltdata" ]
+					Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_INTRAUOBJCOLL_CSLTDATA
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
 		(* interuobjcoll callees slt code section *)
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_interuobjcoll_csltcode", {
-			f_name = "uobj_interuobjcoll_csltcode";	
-			f_subsection_list = [ ".uobj_interuobjcoll_csltcode" ];	
-			usbinformat = { f_type= Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_INTERUOBJCOLL_CSLTCODE; 
-							f_prot=0; 
-							f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-							f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_addr_start=0; 
-							f_addr_file = 0;
-							f_reserved = 0;
-						};
-		}) ];
-
+		l_add_section "uobj_interuobjcoll_csltcode" [ ".uobj_interuobjcoll_csltcode" ]
+					Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_INTERUOBJCOLL_CSLTCODE
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
 		(* interuobjcoll callees slt data section *)
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_interuobjcoll_csltdata", {
-			f_name = "uobj_interuobjcoll_csltdata";	
-			f_subsection_list = [ ".uobj_interuobjcoll_csltdata" ];	
-			usbinformat = { f_type= Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_INTERUOBJCOLL_CSLTDATA; 
-							f_prot=0; 
-							f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-							f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_addr_start=0; 
-							f_addr_file = 0;
-							f_reserved = 0;
-						};
-		}) ];
-
+		l_add_section "uobj_interuobjcoll_csltdata" [ ".uobj_interuobjcoll_csltdata" ]
+					Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_INTERUOBJCOLL_CSLTDATA
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
 		(* legacy callees slt code section *)
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_legacy_csltcode", {
-			f_name = "uobj_legacy_csltcode";	
-			f_subsection_list = [ ".uobj_legacy_csltcode" ];	
-			usbinformat = { f_type= Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_LEGACY_CSLTCODE; 
-							f_prot=0; 
-							f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-							f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_addr_start=0; 
-							f_addr_file = 0;
-							f_reserved = 0;
-						};
-		}) ];
+		l_add_section "uobj_legacy_csltcode" [ ".uobj_legacy_csltcode" ]
+					Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_LEGACY_CSLTCODE
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
 		(* legacy callees slt data section *)
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_legacy_csltdata", {
-			f_name = "uobj_legacy_csltdata";	
-			f_subsection_list = [ ".uobj_legacy_csltdata" ];	
-			usbinformat = { f_type= Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_LEGACY_CSLTDATA; 
-							f_prot=0; 
-							f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-							f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_addr_start=0; 
-							f_addr_file = 0;
-							f_reserved = 0;
-						};
-		}) ];
-
+		l_add_section "uobj_legacy_csltdata" [ ".uobj_legacy_csltdata" ]
+					Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_LEGACY_CSLTDATA 
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
 		(* uobj code, data, dmadata and stack sections follow *)
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_code", {
-				 f_name = "uobj_code";	
-				f_subsection_list = [ ".text" ];	
-				usbinformat = { f_type=Defs.Basedefs.def_USBINFORMAT_SECTION_TYPE_UOBJ_CODE; 
-												f_prot=0; 
-												f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-												f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-												f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-												f_addr_start=0; 
-												f_addr_file = 0;
-												f_reserved = 0;
-											};
-		}) ];
+		l_add_section "uobj_code" [ ".text" ]
+					Defs.Basedefs.def_USBINFORMAT_SECTION_TYPE_UOBJ_CODE 
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_rodata", {
-			 f_name = "uobj_rodata";	
-				f_subsection_list = [".rodata"];	
-				usbinformat = { f_type=Defs.Basedefs.def_USBINFORMAT_SECTION_TYPE_UOBJ_RODATA; 
-												f_prot=0; 
-												f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-												f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-												f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
-												f_addr_start=0; 
-												f_addr_file = 0;
-												f_reserved = 0;
-											};
-		}) ];
+		l_add_section "uobj_rodata" [".rodata"]
+					Defs.Basedefs.def_USBINFORMAT_SECTION_TYPE_UOBJ_RODATA
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_rwdata", {
-			 f_name = "uobj_rwdata";	
-				f_subsection_list = [".data"; ".bss"];	
-				usbinformat = { f_type=Defs.Basedefs.def_USBINFORMAT_SECTION_TYPE_UOBJ_RWDATA; 
-												f_prot=0; 
-												f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-												f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-												f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
-												f_addr_start=0; 
-												f_addr_file = 0;
-												f_reserved = 0;
-											};
-		}) ];
+		l_add_section "uobj_rwdata" [".data"; ".bss"]
+					Defs.Basedefs.def_USBINFORMAT_SECTION_TYPE_UOBJ_RWDATA 
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_dmadata", {
-			 f_name = "uobj_dmadata";	
-				f_subsection_list = [".dmadata"];	
-				usbinformat = { f_type=Defs.Basedefs.def_USBINFORMAT_SECTION_TYPE_UOBJ_DMADATA;
-												f_prot=0; 
-												f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-												f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-												f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
-												f_addr_start=0; 
-												f_addr_file = 0;
-												f_reserved = 0;
-											};
-		}) ];
+		l_add_section "uobj_dmadata" [".dmadata"]
+					Defs.Basedefs.def_USBINFORMAT_SECTION_TYPE_UOBJ_DMADATA
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_ustack", {
-			 f_name = "uobj_ustack";	
-				f_subsection_list = [ ".ustack" ];	
-				usbinformat = { f_type=Defs.Basedefs.def_USBINFORMAT_SECTION_TYPE_UOBJ_USTACK; 
-												f_prot=0; 
-												f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-												f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
-												f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-												f_addr_start=0; 
-												f_addr_file = 0;
-												f_reserved = 0;
-											};
-		}) ];
+		l_add_section "uobj_ustack" [ ".ustack" ]
+					Defs.Basedefs.def_USBINFORMAT_SECTION_TYPE_UOBJ_USTACK 
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_tstack", {
-			 f_name = "uobj_tstack";	
-				f_subsection_list = [ ".tstack"; ".stack" ];	
-				usbinformat = { f_type=Defs.Basedefs.def_USBINFORMAT_SECTION_TYPE_UOBJ_TSTACK; 
-												f_prot=0; 
-												f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-												f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
-												f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-												f_addr_start=0; 
-												f_addr_file = 0;
-												f_reserved = 0;
-											};
-		}) ];
+		l_add_section "uobj_tstack" [ ".tstack"; ".stack" ]
+					Defs.Basedefs.def_USBINFORMAT_SECTION_TYPE_UOBJ_TSTACK 
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
 		()
 	;

--- a/src-nextgen/tools/libs/uberspark_uobj.ml
+++ b/src-nextgen/tools/libs/uberspark_uobj.ml
@@ -1272,7 +1272,7 @@ class uobject
 			Uberspark_namespace.namespace_uobj_linkerscript_filename
 			Uberspark_namespace.namespace_uobj_binary_image_filename
 			!o_file_list
-			[ ] [ ]	".";
+			[ ] [ ]	[ ] ".";
 
 		(!retval)	
 	;

--- a/src-nextgen/tools/libs/uberspark_uobj.ml
+++ b/src-nextgen/tools/libs/uberspark_uobj.ml
@@ -1272,7 +1272,7 @@ class uobject
 			Uberspark_namespace.namespace_uobj_linkerscript_filename
 			Uberspark_namespace.namespace_uobj_binary_image_filename
 			!o_file_list
-			[ ] [ ]	[ "./cclib.a" ] ".";
+			[ ] [ ]	[ ("." ^ "/" ^ Uberspark_namespace.namespace_uobj_cclib_filename) ] ".";
 
 		(!retval)	
 	;

--- a/src-nextgen/tools/libs/uberspark_uobj.ml
+++ b/src-nextgen/tools/libs/uberspark_uobj.ml
@@ -1272,7 +1272,7 @@ class uobject
 			Uberspark_namespace.namespace_uobj_linkerscript_filename
 			Uberspark_namespace.namespace_uobj_binary_image_filename
 			!o_file_list
-			[ ] [ ]	[ Uberspark_bridge.Cc.json_node_uberspark_bridge_cc_var.params_cclib ] ".";
+			[ ] [ ]	[ "./cclib.a" ] ".";
 
 		(!retval)	
 	;

--- a/src-nextgen/tools/libs/uberspark_uobj.ml
+++ b/src-nextgen/tools/libs/uberspark_uobj.ml
@@ -603,28 +603,42 @@ class uobject
 		()
 		: unit =
 		
-		(* start with uobj state save area section *)
-		d_default_sections_list := !d_default_sections_list @ [ ("uobj_ssa", {
-			f_name = "uobj_ssa";	
-			f_subsection_list = [ ".uobj_ssa" ];	
-			usbinformat = { f_type= Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_SSA; 
-							f_prot=0; 
-							f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
-							f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_pad_to = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
-							f_addr_start=0; 
-							f_addr_file = 0;
-							f_reserved = 0;
-						};
-		}) ];
+		let add_section (uobj_f_sections: (string * Defs.Basedefs.section_info_t) list)
+						(section_f_name: string)
+						(section_f_subsection_list : string list)
+						(section_usbinformat_f_type : int)
+						(section_usbinformat_f_prot : int)
+						(section_usbinformat_f_size : int)
+						(section_usbinformat_f_aligned_at : int)
+						(section_usbinformat_f_pad_to : int)
+						: unit =
 
-		(* create sections for each public method *)
-		Hashtbl.iter (fun (pm_name:string) (pm_info:Uberspark_manifest.Uobj.json_node_uberspark_uobj_publicmethods_t)  ->
-			let section_name = ("uobj_pm_" ^ pm_name) in 
-			d_default_sections_list := !d_default_sections_list @ [ (section_name, {
-				f_name = section_name;	
-				f_subsection_list = [ "." ^ section_name ];	
-				usbinformat = { f_type= Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_PMINFO; 
+			let var_sinfo : Defs.Basedefs.section_info_t = {
+				f_name = section_f_name;	
+				f_subsection_list = section_f_subsection_list;	
+				usbinformat = { f_type= section_usbinformat_f_type; 
+								f_prot= section_usbinformat_f_prot; 
+								f_size = section_usbinformat_f_size;
+								f_aligned_at = section_usbinformat_f_aligned_at; 
+								f_pad_to = section_usbinformat_f_pad_to; 
+								f_addr_start=0; 
+								f_addr_file = 0;
+								f_reserved = 0;
+							};
+			} in
+
+			d_default_sections_list := !d_default_sections_list @ [ (section_f_name, var_sinfo) ];
+
+			()
+		in
+
+(*		if (List.mem_assoc "uobj_ssa" json_node_uberspark_uobj_var.f_sections) then begin
+			let var_sinfo : Defs.Basedefs.section_info_t = (List.assoc "uobj_ssa" json_node_uberspark_uobj_var.f_sections) in
+			
+			d_default_sections_list := !d_default_sections_list @ [ ("uobj_ssa", {
+				f_name = "uobj_ssa";	
+				f_subsection_list = [ ".uobj_ssa" ] @ var_sinfo.f_subsection_list;	
+				usbinformat = { f_type= Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_SSA; 
 								f_prot=0; 
 								f_size = Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size;
 								f_aligned_at = Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment; 
@@ -634,6 +648,30 @@ class uobject
 								f_reserved = 0;
 							};
 			}) ];
+
+		end else begin
+*)
+		(* start with uobj state save area section *)
+		add_section json_node_uberspark_uobj_var.f_sections
+					"uobj_ssa" [ ".uobj_ssa" ] 
+					Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_SSA
+					0 
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+					Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
+
+
+		(* create sections for each public method *)
+		Hashtbl.iter (fun (pm_name:string) (pm_info:Uberspark_manifest.Uobj.json_node_uberspark_uobj_publicmethods_t)  ->
+			let section_name = ("uobj_pm_" ^ pm_name) in 
+
+			add_section json_node_uberspark_uobj_var.f_sections
+						section_name [ "." ^ section_name ]
+						Defs.Binformat.const_USBINFORMAT_SECTION_TYPE_UOBJ_PMINFO
+						0 
+						Uberspark_config.json_node_uberspark_config_var.binary_uobj_default_section_size
+						Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment
+						Uberspark_config.json_node_uberspark_config_var.binary_uobj_section_alignment;
 
 		) self#get_d_publicmethods_hashtbl;
 		

--- a/src-nextgen/tools/libs/uberspark_uobj.ml
+++ b/src-nextgen/tools/libs/uberspark_uobj.ml
@@ -1272,7 +1272,7 @@ class uobject
 			Uberspark_namespace.namespace_uobj_linkerscript_filename
 			Uberspark_namespace.namespace_uobj_binary_image_filename
 			!o_file_list
-			[ ] [ ]	[ ] ".";
+			[ ] [ ]	[ Uberspark_bridge.Cc.json_node_uberspark_bridge_cc_var.params_cclib ] ".";
 
 		(!retval)	
 	;

--- a/src-nextgen/tools/libs/uberspark_uobjcoll.ml
+++ b/src-nextgen/tools/libs/uberspark_uobjcoll.ml
@@ -1030,7 +1030,7 @@ let link_binary_image
 		Uberspark_namespace.namespace_uobjcoll_linkerscript_filename
 		Uberspark_namespace.namespace_uobjcoll_binary_image_filename
 		!o_file_list
-		[ ] [ ]	[ Uberspark_bridge.Cc.json_node_uberspark_bridge_cc_var.params_cclib ] ".";
+		[ ] [ ]	[ ] ".";
 
 	(!retval)	
 ;;

--- a/src-nextgen/tools/libs/uberspark_uobjcoll.ml
+++ b/src-nextgen/tools/libs/uberspark_uobjcoll.ml
@@ -1030,7 +1030,7 @@ let link_binary_image
 		Uberspark_namespace.namespace_uobjcoll_linkerscript_filename
 		Uberspark_namespace.namespace_uobjcoll_binary_image_filename
 		!o_file_list
-		[ ] [ ]	".";
+		[ ] [ ]	[ ] ".";
 
 	(!retval)	
 ;;

--- a/src-nextgen/tools/libs/uberspark_uobjcoll.ml
+++ b/src-nextgen/tools/libs/uberspark_uobjcoll.ml
@@ -1030,7 +1030,7 @@ let link_binary_image
 		Uberspark_namespace.namespace_uobjcoll_linkerscript_filename
 		Uberspark_namespace.namespace_uobjcoll_binary_image_filename
 		!o_file_list
-		[ ] [ ]	[ ] ".";
+		[ ] [ ]	[ Uberspark_bridge.Cc.json_node_uberspark_bridge_cc_var.params_cclib ] ".";
 
 	(!retval)	
 ;;

--- a/src-nextgen/tools/libs/uberspark_uobjcoll.ml
+++ b/src-nextgen/tools/libs/uberspark_uobjcoll.ml
@@ -1029,6 +1029,7 @@ let link_binary_image
 			~context_path_builddir:Uberspark_namespace.namespace_uobjcoll_build_dir 
 		Uberspark_namespace.namespace_uobjcoll_linkerscript_filename
 		Uberspark_namespace.namespace_uobjcoll_binary_image_filename
+		Uberspark_namespace.namespace_uobjcoll_binary_flat_image_filename
 		!o_file_list
 		[ ] [ ]	[ ] ".";
 

--- a/src-nextgen/tools/libs/uberspark_uobjcoll.ml
+++ b/src-nextgen/tools/libs/uberspark_uobjcoll.ml
@@ -559,7 +559,7 @@ let consolidate_sections_with_memory_map
 		
 			(* add section *)
 			let sentinel_name = pm_name ^ "__" ^ sentinel_type in 
-			let key = (".section_uobjcoll_publicmethod_sentinel_" ^ sentinel_name) in 
+			let key = (".section_uobjcoll_publicmethod_sentinel__" ^ sentinel_name) in 
 			let sentinel_info = Hashtbl.find d_uobjcoll_publicmethods_sentinels_hashtbl sentinel_type in
 			let section_size = 	sentinel_info.f_sizeof_code + (Uberspark_config.json_node_uberspark_config_var.uobjcoll_binary_image_section_alignment - 
 				(sentinel_info.f_sizeof_code mod Uberspark_config.json_node_uberspark_config_var.uobjcoll_binary_image_section_alignment)) in
@@ -602,7 +602,7 @@ let consolidate_sections_with_memory_map
 
 			(* add section *)
 			let sentinel_name = pm_name ^ "__" ^ sentinel_type in 
-			let key = (".section_intrauobjcoll_publicmethod_sentinel_" ^ sentinel_name) in 
+			let key = (".section_intrauobjcoll_publicmethod_sentinel__" ^ sentinel_name) in 
 			let sentinel_info = Hashtbl.find d_uobjcoll_intrauobjcoll_sentinels_hashtbl sentinel_type in
 			let section_size = 	sentinel_info.f_sizeof_code + (Uberspark_config.json_node_uberspark_config_var.uobjcoll_binary_image_section_alignment - 
 				(sentinel_info.f_sizeof_code mod Uberspark_config.json_node_uberspark_config_var.uobjcoll_binary_image_section_alignment)) in
@@ -796,7 +796,7 @@ let prepare_for_uobjcoll_sentinel_codegen
 			let codegen_sinfo_entry : Uberspark_codegen.Uobjcoll.sentinel_info_t = { 
 				f_type= sentinel_type;
 				f_name = canonical_pm_name ^ "__" ^ sentinel_type; 
-				f_secname = ".section_uobjcoll_publicmethods_sentinel__" ^ (canonical_pm_name ^ "__" ^ sentinel_type);
+				f_secname = ".section_uobjcoll_publicmethod_sentinel__" ^ (canonical_pm_name ^ "__" ^ sentinel_type);
 				f_code = sentinel_info.f_code ; 
 				f_libcode= sentinel_info.f_libcode ; 
 				f_sizeof_code= sentinel_info.f_sizeof_code ; 
@@ -820,7 +820,7 @@ let prepare_for_uobjcoll_sentinel_codegen
 			let codegen_sinfo_entry : Uberspark_codegen.Uobjcoll.sentinel_info_t = { 
 				f_type= sentinel_type;
 				f_name = canonical_pm_name ^ "__" ^ sentinel_type; 
-				f_secname = ".section_intrauobjcoll_sentinel__" ^ (canonical_pm_name ^ "__" ^ sentinel_type);
+				f_secname = ".section_intrauobjcoll_publicmethod_sentinel__" ^ (canonical_pm_name ^ "__" ^ sentinel_type);
 				f_code = sentinel_info.f_code ; 
 				f_libcode= sentinel_info.f_libcode ; 
 				f_sizeof_code= sentinel_info.f_sizeof_code ; 
@@ -874,7 +874,7 @@ let setup_uobjcoll_publicmethods_sentinel_address_hashtbl
 	List.iter ( fun ( (canonical_pm_name:string), (pm_sentinel_info:Uberspark_manifest.Uobjcoll.json_node_uberspark_uobjcoll_publicmethods_t))  ->
 		List.iter ( fun (sentinel_type:string) ->
 			let canonical_pm_sentinel_name = (canonical_pm_name ^ "__" ^ sentinel_type) in 
-			let key = (".section_uobjcoll_publicmethod_sentinel_" ^ canonical_pm_sentinel_name) in 
+			let key = (".section_uobjcoll_publicmethod_sentinel__" ^ canonical_pm_sentinel_name) in 
 
 			(* grab section information for this sentinel *)
 			let section_info = (List.assoc key !d_memorymapped_sections_list) in
@@ -914,7 +914,7 @@ let setup_intrauobjcoll_publicmethods_sentinel_address_hashtbl
 	List.iter (fun ((canonical_pm_name:string) ,(throwaway:Uberspark_uobj.publicmethod_info_t))  ->
 		List.iter ( fun (sentinel_type:string) ->
 			let canonical_pm_sentinel_name = (canonical_pm_name ^ "__" ^ sentinel_type) in 
-			let key = (".section_intrauobjcoll_publicmethod_sentinel_" ^ canonical_pm_sentinel_name) in 
+			let key = (".section_intrauobjcoll_publicmethod_sentinel__" ^ canonical_pm_sentinel_name) in 
 
 			(* grab section information for this sentinel *)
 			let section_info = (List.assoc key !d_memorymapped_sections_list) in


### PR DESCRIPTION
Add cc-bridge support to hook in compiler runtime library (e.g., libgcc.a) within nextgen tool-chain. Also fix top-level uberspark.h to use crt üobj runtime library headers instead of standard header files so we avoid namespace/type conflict