### PR TITLE
Feature Fix Build errors with CompCert containers & GCC 5.5.0 containers for x86

### DIFF
--- a/build-trusses/build-x86_64.Dockerfile
+++ b/build-trusses/build-x86_64.Dockerfile
@@ -52,15 +52,14 @@ RUN pip3 install breathe==4.18.1
 
 # install doxygen
 WORKDIR "/home/uberspark"
-RUN wget -O doxygen-Release_1_8_20.tar.gz https://github.com/doxygen/doxygen/archive/Release_1_8_20.tar.gz
-RUN tar -xzf ./doxygen-Release_1_8_20.tar.gz
-WORKDIR "/home/uberspark/doxygen-Release_1_8_20"
-RUN  mkdir build
-WORKDIR "/home/uberspark/doxygen-Release_1_8_20/build"
-RUN cmake -G "Unix Makefiles" .. &&\
+RUN wget -O doxygen-Release_1_8_20.tar.gz https://github.com/doxygen/doxygen/archive/Release_1_8_20.tar.gz && \
+    tar -xzf ./doxygen-Release_1_8_20.tar.gz   && \
+    cd doxygen-Release_1_8_20 && \
+    mkdir build && cd build && \
+    cmake -G "Unix Makefiles" .. &&\
     make &&\
-    make install 
-
+    make install && cd ../.. && \
+    rm -rf doxygen-Release_1_8_20.tar.gz 
 
 # switch user to uberspark working directory to /home/uberspark
 USER uberspark
@@ -98,4 +97,3 @@ WORKDIR "/home/uberspark/uberspark/build-trusses"
 
 # invoke the entrypoint script which will adjust uid/gid and invoke d_cmd with d_cmdargs as user uberspark
 CMD /docker-entrypoint.sh ${D_UID} ${D_GID} ${D_CMD} ${D_CMDARGS}
-

--- a/docs/nextgen-toolkit/genuser-guide/install.rst
+++ b/docs/nextgen-toolkit/genuser-guide/install.rst
@@ -13,9 +13,9 @@ You will need to build the |uspark| toolchain before performing any other
 task.
 
 
-.. note:: The |uspark| toolchain requires approximately 2.4 GB of disk space.
+.. note:: The |uspark| toolchain requires approximately 2.4 GB of disk space. Additionally, it is recommended to have configured at least 4GB-6GB of container memory.
 
-	  
+
 	  
 To achieve this, you need to issue the following command while in the
 top-level directory of 
@@ -87,5 +87,4 @@ the |uspark| source-tree (the directory where the file RELEASE is located):
           docker is unable to mount host folders that are part of the WSL Linux filesystem (e.g., ``~/``) 
           under Windows.
 
-
-
+.. note:: Insufficient container memory could manifest as an ``Error 137`` when building bridges. It is recommended to increase your container memory configuration if you experience these errors.

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/compiler_script.sh
@@ -27,5 +27,4 @@ echo "PATH after mod: $PATH"
 
 ./configure x86_32-linux
 make -j4 all
-exit
 make install

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/compiler_script.sh
@@ -14,10 +14,7 @@ echo "archive_dir: $archive_dir"
 
 cd $archive_dir
 
-#find / -name 'ocaml'
-
 echo "PATH: $PATH"
-ls -alR /home/ubuntu/.opam
 
 su ubuntu
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/uberspark-bridge.Dockerfile
@@ -6,23 +6,8 @@ MAINTAINER David Shepard <djshepard@sei.cmu.edu>
 ENV archive_name=compcert-3.1.tgz
 
 RUN apt-get update &&\
-    apt-get -y install wget
-
-# Put everything in the build context.
-RUN wget http://compcert.inria.fr/release/${archive_name}
-
-RUN mv compcert-3.1.tgz CompCert-3.1.tgz
-RUN mv CompCert-3.1.tgz /tmp
-ENV archive_name=CompCert-3.1.tgz
-
-COPY install.sh /tmp
-COPY compiler_script.sh /tmp
-
-# This didn't work because Opam asks questions, lots of them. I have a
-# custom install.sh that is in the build directory. We just call that instead.
-# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
-
-RUN apt-get -y install  \
+    apt-get -y install \
+    	wget \
         gcc-8 \
         gcc-8-multilib-arm-linux-gnueabihf \
         gcc-8-multilib-x86-64-linux-gnux32 \
@@ -36,8 +21,21 @@ RUN apt-get -y install  \
         unzip \
         gawk \
         findutils \
-        build-essential &&\
-    cd /tmp &&\
+        build-essential
+
+# Put everything in the build context.
+RUN wget http://compcert.inria.fr/release/${archive_name}
+
+RUN mv compcert-3.1.tgz /tmp/CompCert-3.1.tgz
+ENV archive_name=CompCert-3.1.tgz
+
+COPY install.sh compiler_script.sh /tmp/
+
+# This didn't work because Opam asks questions, lots of them. I have a
+# custom install.sh that is in the build directory. We just call that instead.
+# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
+
+RUN cd /tmp &&\
     chmod 755 install.sh &&\
     chmod 755 compiler_script.sh &&\
     ./install.sh &&\
@@ -95,17 +93,8 @@ RUN tar -xzf ${archive_name}
 # Docker builds, you need to do substring parsing with an awk script. That's
 # done in compiler_script.sh
 
-#RUN archive_dir=${archive_name:0:$archive_string_len-4}
-
 RUN . ./compiler_script.sh
 
 USER ubuntu
 WORKDIR /home/ubuntu
-
-# After your container builds, you can run it with:
-
-# docker run -it -u ubuntu compcert-v3.1:latest /bin/bash
-
-# Please have a look around, see if everything works as expected. We can fix
-# whatever isn't ready for use yet.
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/uberspark-bridge.Dockerfile
@@ -95,6 +95,5 @@ RUN tar -xzf ${archive_name}
 
 RUN . ./compiler_script.sh
 
-USER ubuntu
-WORKDIR /home/ubuntu
+WORKDIR /home
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/uberspark.json
@@ -12,20 +12,20 @@
 
     "uberspark-bridge-cc" : {
 		/* bridge header */
-		"bridge-hdr":{
-			"btype" : "container",
-			"bname" : "compcert",
-			"execname" : "ccomp",
-			"devenv" : "amd64",
-			"arch" : "x86_32",
-			"cpu" : "generic",
-			"version" : "v3.1",
-			"path" : ".",
-			"params" : [ "" ],
-			"container_fname" : "uberspark_bridges.Dockerfile"
+	        "bridge-hdr":{
+		    "btype" : "container",
+		    "bname" : "compcert",
+		    "execname" : "ccomp",
+		    "devenv" : "amd64",
+		    "arch" : "x86_32",
+		    "cpu" : "generic",
+		    "version" : "v3.1",
+		    "path" : ".",
+		    "params" : [ "" ],
+		    "container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
-		"params_prefix_obj" : "-c",
+	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
         "params_prefix_include" : "-I"

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/compiler_script.sh
@@ -27,5 +27,4 @@ echo "PATH after mod: $PATH"
 
 ./configure x86_32-linux
 make -j4 all
-exit
 make install

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/compiler_script.sh
@@ -14,10 +14,7 @@ echo "archive_dir: $archive_dir"
 
 cd $archive_dir
 
-#find / -name 'ocaml'
-
 echo "PATH: $PATH"
-ls -alR /home/ubuntu/.opam
 
 su ubuntu
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark-bridge.Dockerfile
@@ -93,9 +93,8 @@ RUN tar -xzf ${archive_name}
 # Docker builds, you need to do substring parsing with an awk script. That's
 # done in compiler_script.sh
 
-#RUN archive_dir=${archive_name:0:$archive_string_len-4}
-
 RUN . ./compiler_script.sh
 
 USER ubuntu
 WORKDIR /home/ubuntu
+

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark-bridge.Dockerfile
@@ -6,23 +6,8 @@ MAINTAINER David Shepard <djshepard@sei.cmu.edu>
 ENV archive_name=compcert-3.2.tgz
 
 RUN apt-get update &&\
-    apt-get -y install wget
-
-# Put everything in the build context.
-RUN wget http://compcert.inria.fr/release/${archive_name}
-
-RUN mv compcert-3.2.tgz CompCert-3.2.tgz
-RUN mv CompCert-3.2.tgz /tmp
-ENV archive_name=CompCert-3.2.tgz
-
-COPY install.sh /tmp
-COPY compiler_script.sh /tmp
-
-# This didn't work because Opam asks questions, lots of them. I have a
-# custom install.sh that is in the build directory. We just call that instead.
-# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
-
-RUN apt-get -y install  \
+    apt-get -y install \
+    	wget \
         gcc-8 \
         gcc-8-multilib-arm-linux-gnueabihf \
         gcc-8-multilib-x86-64-linux-gnux32 \
@@ -36,8 +21,21 @@ RUN apt-get -y install  \
         unzip \
         gawk \
         findutils \
-        build-essential &&\
-    cd /tmp &&\
+        build-essential
+
+# Put everything in the build context.
+RUN wget http://compcert.inria.fr/release/${archive_name}
+
+RUN mv compcert-3.2.tgz /tmp/CompCert-3.2.tgz
+ENV archive_name=CompCert-3.2.tgz
+
+COPY install.sh compiler_script.sh /tmp/
+
+# This didn't work because Opam asks questions, lots of them. I have a
+# custom install.sh that is in the build directory. We just call that instead.
+# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
+
+RUN cd /tmp &&\
     chmod 755 install.sh &&\
     chmod 755 compiler_script.sh &&\
     ./install.sh &&\
@@ -101,11 +99,3 @@ RUN . ./compiler_script.sh
 
 USER ubuntu
 WORKDIR /home/ubuntu
-
-# After your container builds, you can run it with:
-
-# docker run -it -u ubuntu compcert-v3.2:latest /bin/bash
-
-# Please have a look around, see if everything works as expected. We can fix
-# whatever isn't ready for use yet.
-

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark-bridge.Dockerfile
@@ -95,6 +95,5 @@ RUN tar -xzf ${archive_name}
 
 RUN . ./compiler_script.sh
 
-USER ubuntu
-WORKDIR /home/ubuntu
+WORKDIR /home
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark.json
@@ -25,7 +25,7 @@
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
-		"params_prefix_obj" : "-c",
+	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
         "params_prefix_include" : "-I"

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/compiler_script.sh
@@ -27,5 +27,4 @@ echo "PATH after mod: $PATH"
 
 ./configure x86_32-linux
 make -j4 all
-exit
 make install

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/compiler_script.sh
@@ -14,10 +14,7 @@ echo "archive_dir: $archive_dir"
 
 cd $archive_dir
 
-#find / -name 'ocaml'
-
 echo "PATH: $PATH"
-ls -alR /home/ubuntu/.opam
 
 su ubuntu
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/uberspark-bridge.Dockerfile
@@ -96,7 +96,6 @@ RUN tar -xzf ${archive_name}
 
 RUN . ./compiler_script.sh
 
-USER ubuntu
-WORKDIR /home/ubuntu
+WORKDIR /home
 
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/uberspark-bridge.Dockerfile
@@ -2,27 +2,11 @@ FROM ubuntu:18.04
 MAINTAINER David Shepard <djshepard@sei.cmu.edu>
 
 # Also pass in the name of the compiler archive file.
-
 ENV archive_name=compcert-3.3.tgz
 
 RUN apt-get update &&\
-    apt-get -y install wget
-
-# Put everything in the build context.
-RUN wget http://compcert.inria.fr/release/${archive_name}
-
-RUN mv compcert-3.3.tgz CompCert-3.3.tgz
-RUN mv CompCert-3.3.tgz /tmp
-ENV archive_name=CompCert-3.3.tgz
-
-COPY install.sh /tmp
-COPY compiler_script.sh /tmp
-
-# This didn't work because Opam asks questions, lots of them. I have a
-# custom install.sh that is in the build directory. We just call that instead.
-# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
-
-RUN apt-get -y install  \
+    apt-get -y install \
+        wget \
         gcc-8 \
         gcc-8-multilib-arm-linux-gnueabihf \
         gcc-8-multilib-x86-64-linux-gnux32 \
@@ -36,8 +20,21 @@ RUN apt-get -y install  \
         unzip \
         gawk \
         findutils \
-        build-essential &&\
-    cd /tmp &&\
+        build-essential
+
+# Put everything in the build context.
+RUN wget http://compcert.inria.fr/release/${archive_name}
+
+RUN mv compcert-3.3.tgz /tmp/CompCert-3.3.tgz
+ENV archive_name=CompCert-3.3.tgz
+
+COPY install.sh compiler_script.sh /tmp/
+
+# This didn't work because Opam asks questions, lots of them. I have a
+# custom install.sh that is in the build directory. We just call that instead.
+# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
+
+RUN cd /tmp &&\
     chmod 755 install.sh &&\
     chmod 755 compiler_script.sh &&\
     ./install.sh &&\
@@ -102,10 +99,4 @@ RUN . ./compiler_script.sh
 USER ubuntu
 WORKDIR /home/ubuntu
 
-# After your container builds, you can run it with:
-
-# docker run -it -u ubuntu compcert-v3.3:latest /bin/bash
-
-# Please have a look around, see if everything works as expected. We can fix
-# whatever isn't ready for use yet.
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/uberspark.json
@@ -25,7 +25,7 @@
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
-		"params_prefix_obj" : "-c",
+	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
         "params_prefix_include" : "-I"

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/compiler_script.sh
@@ -27,5 +27,4 @@ echo "PATH after mod: $PATH"
 
 ./configure x86_32-linux
 make -j4 all
-exit
 make install

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/compiler_script.sh
@@ -14,10 +14,7 @@ echo "archive_dir: $archive_dir"
 
 cd $archive_dir
 
-#find / -name 'ocaml'
-
 echo "PATH: $PATH"
-ls -alR /home/ubuntu/.opam
 
 su ubuntu
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/uberspark-bridge.Dockerfile
@@ -96,6 +96,5 @@ RUN tar -xzf ${archive_name}
 
 RUN . ./compiler_script.sh
 
-USER ubuntu
-WORKDIR /home/ubuntu
+WORKDIR /home
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/uberspark-bridge.Dockerfile
@@ -6,23 +6,8 @@ MAINTAINER David Shepard <djshepard@sei.cmu.edu>
 ENV archive_name=compcert-3.4.tgz
 
 RUN apt-get update &&\
-    apt-get -y install wget
-
-# Put everything in the build context.
-RUN wget http://compcert.inria.fr/release/${archive_name}
-
-RUN mv compcert-3.4.tgz CompCert-3.4.tgz
-RUN mv CompCert-3.4.tgz /tmp
-ENV archive_name=CompCert-3.4.tgz
-
-COPY install.sh /tmp
-COPY compiler_script.sh /tmp
-
-# This didn't work because Opam asks questions, lots of them. I have a
-# custom install.sh that is in the build directory. We just call that instead.
-# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
-
-RUN apt-get -y install  \
+    apt-get -y install \
+        wget \
         gcc-8 \
         gcc-8-multilib-arm-linux-gnueabihf \
         gcc-8-multilib-x86-64-linux-gnux32 \
@@ -36,8 +21,21 @@ RUN apt-get -y install  \
         unzip \
         gawk \
         findutils \
-        build-essential &&\
-    cd /tmp &&\
+        build-essential
+
+# Put everything in the build context.
+RUN wget http://compcert.inria.fr/release/${archive_name}
+
+RUN mv compcert-3.4.tgz /tmp/CompCert-3.4.tgz
+ENV archive_name=CompCert-3.4.tgz
+
+COPY install.sh compiler_script.sh /tmp/
+
+# This didn't work because Opam asks questions, lots of them. I have a
+# custom install.sh that is in the build directory. We just call that instead.
+# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
+
+RUN cd /tmp &&\
     chmod 755 install.sh &&\
     chmod 755 compiler_script.sh &&\
     ./install.sh &&\
@@ -75,7 +73,6 @@ RUN opam init --disable-sandboxing &&\
     opam install ocamlbuild=0.14.0 &&\
     opam install menhir.20180528
 
-
 # Build directions say you only need to run like four opam commands to get it
 # installed. If you don't want opam to ask you a lot of questions in your
 # script, since they don't respect any form of auto-answer I could think of
@@ -101,11 +98,4 @@ RUN . ./compiler_script.sh
 
 USER ubuntu
 WORKDIR /home/ubuntu
-
-# After your container builds, you can run it with:
-
-# docker run -it -u ubuntu compcert-v3.4:latest /bin/bash
-
-# Please have a look around, see if everything works as expected. We can fix
-# whatever isn't ready for use yet.
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/uberspark.json
@@ -25,7 +25,7 @@
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
-		"params_prefix_obj" : "-c",
+	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
         "params_prefix_include" : "-I"

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/compiler_script.sh
@@ -27,5 +27,4 @@ echo "PATH after mod: $PATH"
 
 ./configure x86_32-linux
 make -j4 all
-exit
 make install

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/compiler_script.sh
@@ -14,10 +14,7 @@ echo "archive_dir: $archive_dir"
 
 cd $archive_dir
 
-#find / -name 'ocaml'
-
 echo "PATH: $PATH"
-ls -alR /home/ubuntu/.opam
 
 su ubuntu
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/uberspark-bridge.Dockerfile
@@ -6,23 +6,8 @@ MAINTAINER David Shepard <djshepard@sei.cmu.edu>
 ENV archive_name=compcert-3.5.tgz
 
 RUN apt-get update &&\
-    apt-get -y install wget
-
-# Put everything in the build context.
-RUN wget http://compcert.inria.fr/release/${archive_name}
-
-RUN mv compcert-3.5.tgz CompCert-3.5.tgz
-RUN mv CompCert-3.5.tgz /tmp
-ENV archive_name=CompCert-3.5.tgz
-
-COPY install.sh /tmp
-COPY compiler_script.sh /tmp
-
-# This didn't work because Opam asks questions, lots of them. I have a
-# custom install.sh that is in the build directory. We just call that instead.
-# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
-
-RUN apt-get -y install  \
+    apt-get -y install \
+        wget \
         gcc-8 \
         gcc-8-multilib-arm-linux-gnueabihf \
         gcc-8-multilib-x86-64-linux-gnux32 \
@@ -36,8 +21,21 @@ RUN apt-get -y install  \
         unzip \
         gawk \
         findutils \
-        build-essential &&\
-    cd /tmp &&\
+        build-essential
+
+# Put everything in the build context.
+RUN wget http://compcert.inria.fr/release/${archive_name}
+
+RUN mv compcert-3.5.tgz /tmp/CompCert-3.5.tgz
+ENV archive_name=CompCert-3.5.tgz
+
+COPY install.sh compiler_script.sh /tmp/
+
+# This didn't work because Opam asks questions, lots of them. I have a
+# custom install.sh that is in the build directory. We just call that instead.
+# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
+
+RUN cd /tmp &&\
     chmod 755 install.sh &&\
     chmod 755 compiler_script.sh &&\
     ./install.sh &&\
@@ -101,11 +99,3 @@ RUN . ./compiler_script.sh
 
 USER ubuntu
 WORKDIR /home/ubuntu
-
-# After your container builds, you can run it with:
-
-# docker run -it -u ubuntu compcert-v3.5:latest /bin/bash
-
-# Please have a look around, see if everything works as expected. We can fix
-# whatever isn't ready for use yet.
-

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/uberspark-bridge.Dockerfile
@@ -97,5 +97,4 @@ RUN tar -xzf ${archive_name}
 
 RUN . ./compiler_script.sh
 
-USER ubuntu
-WORKDIR /home/ubuntu
+WORKDIR /home

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/uberspark.json
@@ -25,7 +25,7 @@
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
-		"params_prefix_obj" : "-c",
+	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
         "params_prefix_include" : "-I"

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/compiler_script.sh
@@ -27,5 +27,4 @@ echo "PATH after mod: $PATH"
 
 ./configure x86_32-linux
 make -j4 all
-exit
 make install

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/compiler_script.sh
@@ -14,10 +14,7 @@ echo "archive_dir: $archive_dir"
 
 cd $archive_dir
 
-#find / -name 'ocaml'
-
 echo "PATH: $PATH"
-ls -alR /home/ubuntu/.opam
 
 su ubuntu
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/uberspark-bridge.Dockerfile
@@ -6,23 +6,8 @@ MAINTAINER David Shepard <djshepard@sei.cmu.edu>
 ENV archive_name=compcert-3.6.tgz
 
 RUN apt-get update &&\
-    apt-get -y install wget
-
-# Put everything in the build context.
-RUN wget http://compcert.inria.fr/release/${archive_name}
-
-RUN mv compcert-3.6.tgz CompCert-3.6.tgz
-RUN mv CompCert-3.6.tgz /tmp
-ENV archive_name=CompCert-3.6.tgz
-
-COPY install.sh /tmp
-COPY compiler_script.sh /tmp
-
-# This didn't work because Opam asks questions, lots of them. I have a
-# custom install.sh that is in the build directory. We just call that instead.
-# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
-
-RUN apt-get -y install  \
+    apt-get -y install \
+        wget \
         gcc-8 \
         gcc-8-multilib-arm-linux-gnueabihf \
         gcc-8-multilib-x86-64-linux-gnux32 \
@@ -36,8 +21,21 @@ RUN apt-get -y install  \
         unzip \
         gawk \
         findutils \
-        build-essential &&\
-    cd /tmp &&\
+        build-essential
+
+# Put everything in the build context.
+RUN wget http://compcert.inria.fr/release/${archive_name}
+
+RUN mv compcert-3.6.tgz /tmp/CompCert-3.6.tgz
+ENV archive_name=CompCert-3.6.tgz
+
+COPY install.sh compiler_script.sh /tmp/
+
+# This didn't work because Opam asks questions, lots of them. I have a
+# custom install.sh that is in the build directory. We just call that instead.
+# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
+
+RUN cd /tmp &&\
     chmod 755 install.sh &&\
     chmod 755 compiler_script.sh &&\
     ./install.sh &&\
@@ -101,11 +99,4 @@ RUN . ./compiler_script.sh
 
 USER ubuntu
 WORKDIR /home/ubuntu
-
-# After your container builds, you can run it with:
-
-# docker run -it -u ubuntu compcert-v3.6:latest /bin/bash
-
-# Please have a look around, see if everything works as expected. We can fix
-# whatever isn't ready for use yet.
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/uberspark-bridge.Dockerfile
@@ -97,6 +97,5 @@ RUN tar -xzf ${archive_name}
 
 RUN . ./compiler_script.sh
 
-USER ubuntu
-WORKDIR /home/ubuntu
+WORKDIR /home
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/uberspark.json
@@ -25,7 +25,7 @@
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
-		"params_prefix_obj" : "-c",
+	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
         "params_prefix_include" : "-I"

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/compiler_script.sh
@@ -27,5 +27,4 @@ echo "PATH after mod: $PATH"
 
 ./configure x86_32-linux
 make -j4 all
-exit
 make install

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/compiler_script.sh
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/compiler_script.sh
@@ -14,10 +14,7 @@ echo "archive_dir: $archive_dir"
 
 cd $archive_dir
 
-#find / -name 'ocaml'
-
 echo "PATH: $PATH"
-ls -alR /home/ubuntu/.opam
 
 su ubuntu
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/uberspark-bridge.Dockerfile
@@ -6,23 +6,8 @@ MAINTAINER David Shepard <djshepard@sei.cmu.edu>
 ENV archive_name=compcert-3.7.tgz
 
 RUN apt-get update &&\
-    apt-get -y install wget
-
-# Put everything in the build context.
-RUN wget http://compcert.inria.fr/release/${archive_name}
-
-RUN mv compcert-3.7.tgz CompCert-3.7.tgz
-RUN mv CompCert-3.7.tgz /tmp
-ENV archive_name=CompCert-3.7.tgz
-
-COPY install.sh /tmp
-COPY compiler_script.sh /tmp
-
-# This didn't work because Opam asks questions, lots of them. I have a
-# custom install.sh that is in the build directory. We just call that instead.
-# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
-
-RUN apt-get -y install  \
+    apt-get -y install \
+        wget \
         gcc-8 \
         gcc-8-multilib-arm-linux-gnueabihf \
         gcc-8-multilib-x86-64-linux-gnux32 \
@@ -36,8 +21,21 @@ RUN apt-get -y install  \
         unzip \
         gawk \
         findutils \
-        build-essential &&\
-    cd /tmp &&\
+        build-essential
+
+# Put everything in the build context.
+RUN wget http://compcert.inria.fr/release/${archive_name}
+
+RUN mv compcert-3.7.tgz /tmp/CompCert-3.7.tgz
+ENV archive_name=CompCert-3.7.tgz
+
+COPY install.sh compiler_script.sh /tmp/
+
+# This didn't work because Opam asks questions, lots of them. I have a
+# custom install.sh that is in the build directory. We just call that instead.
+# curl https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh -O &&\
+
+RUN cd /tmp &&\
     chmod 755 install.sh &&\
     chmod 755 compiler_script.sh &&\
     ./install.sh &&\
@@ -101,11 +99,3 @@ RUN . ./compiler_script.sh
 
 USER ubuntu
 WORKDIR /home/ubuntu
-
-# After your container builds, you can run it with:
-
-# docker run -it -u ubuntu compcert-v3.6:latest /bin/bash
-
-# Please have a look around, see if everything works as expected. We can fix
-# whatever isn't ready for use yet.
-

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/uberspark-bridge.Dockerfile
@@ -97,5 +97,4 @@ RUN tar -xzf ${archive_name}
 
 RUN . ./compiler_script.sh
 
-USER ubuntu
-WORKDIR /home/ubuntu
+WORKDIR /home

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/uberspark.json
@@ -25,7 +25,7 @@
 			"container_fname" : "uberspark_bridges.Dockerfile"
 		},
 
-		"params_prefix_obj" : "-c",
+	"params_prefix_obj" : "-c",
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
         "params_prefix_include" : "-I"

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/gcc/v5.5.0/uberspark-bridge.Dockerfile
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/gcc/v5.5.0/uberspark-bridge.Dockerfile
@@ -3,6 +3,5 @@ LABEL maintainer="Amit Vasudevan <amitvasudevan@acm.org>, Matt McCormack <matthe
 
 RUN apt-get update &&\
     apt-get -yqq install gcc-5 gcc-5-multilib binutils &&\
-    apt-get clean && rm -rf /var/lib/apt/lists/* &&\
-    ln -s /usr/bin/gcc-5 /usr/bin/gcc
+    apt-get clean && rm -rf /var/lib/apt/lists/* 
 


### PR DESCRIPTION
Updates to fix build errors with compcert and gcc bridges. Changes include: placing all apt-get installs in a single RUN, removing ls -l call, installing compcert, removing bad symlink in gcc, and adding documentation about required container memory.