### PR TITLE
fixed naming of casm funccalls in e1000.h

### DIFF
--- a/src-nextgen/hwm/include/device/net/ethernet/intel/e1000/e1000.h
+++ b/src-nextgen/hwm/include/device/net/ethernet/intel/e1000/e1000.h
@@ -74,12 +74,12 @@
 //#define e1000_readb(addr)		*(volatile unsigned char *)(addr)
 //#define e1000_writeb(value, addr)	*(volatile unsigned char *)(addr) = (uint8_t)(value)
 
-#define e1000_readl(addr)		CASM_FUNCCALL(xmhfhw_sysmemaccess_readu32, addr)
-#define e1000_writel(value, addr)	CASM_FUNCCALL(xmhfhw_sysmemaccess_writeu32, addr, value)
-#define e1000_readw(addr)		CASM_FUNCCALL(xmhfhw_sysmemaccess_readu16, addr)
-#define e1000_writew(value, addr)	CASM_FUNCCALL(xmhfhw_sysmemaccess_writeu16, addr, (uint16_t)value)
-#define e1000_readb(addr)		CASM_FUNCCALL(xmhfhw_sysmemaccess_readu8, addr)
-#define e1000_writeb(value, addr)	CASM_FUNCCALL(xmhfhw_sysmemaccess_writeu8, addr, (uint8_t)value)
+#define e1000_readl(addr)		CASM_FUNCCALL(uberspark_uobjrtl_hw__generic_x86_32_intel__sysmemaccess_readu32, addr)
+#define e1000_writel(value, addr)	CASM_FUNCCALL(uberspark_uobjrtl_hw__generic_x86_32_intel__sysmemaccess_writeu32, addr, value)
+#define e1000_readw(addr)		CASM_FUNCCALL(uberspark_uobjrtl_hw__generic_x86_32_intel__sysmemaccess_readu16, addr)
+#define e1000_writew(value, addr)	CASM_FUNCCALL(uberspark_uobjrtl_hw__generic_x86_32_intel__sysmemaccess_writeu16, addr, (uint16_t)value)
+#define e1000_readb(addr)		CASM_FUNCCALL(uberspark_uobjrtl_hw__generic_x86_32_intel__sysmemaccess_readu8, addr)
+#define e1000_writeb(value, addr)	CASM_FUNCCALL(uberspark_uobjrtl_hw__generic_x86_32_intel__sysmemaccess_writeu8, addr, (uint8_t)value)
 
 /* 128M configuration, two descriptors describe one 8K packet */
 #define E1000_DESC_COUNT	0x1		// no. of descriptors

--- a/src-nextgen/uobjrtl/hw/src/generic/x86_32/intel/sysmem_getacpirsdp.c
+++ b/src-nextgen/uobjrtl/hw/src/generic/x86_32/intel/sysmem_getacpirsdp.c
@@ -104,7 +104,7 @@ static uint32_t _acpi_computetablechecksum(char *table, uint32_t size){
 	requires \valid(rsdp);
 	assigns \nothing;
 @*/
-uint32_t uberspark_uobjrtl_hw__generic_x86_32_intel__platform_x86pc_acpi_getRSDP(ACPI_RSDP *rsdp){
+uint32_t uberspark_uobjrtl_hw__generic_x86_32_intel__acpi_getRSDP(ACPI_RSDP *rsdp){
   uint16_t ebdaseg;
   uint32_t ebdaphys;
   uint32_t i, found=0;


### PR DESCRIPTION
fixes `CASM_FUNCCALL`s in `src-nextgen/hwm/include/device/net/ethernet/intel/e1000/e1000.h` to use new function names.