### PR TITLE
Fixes cc bridge tools libs

### DIFF
--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/uberspark.json
@@ -1,36 +1,37 @@
 /*
     uberSpark code bridges json definition
 */
-
 {
-   	/* manifest header */
-	   "uberspark-manifest":{
-		"manifest_node_types" : [ "uberspark-bridge-cc" ],
-		"uberspark_min_version" : "any",
-		"uberspark_max_version" : "any"
+	/* manifest header */
+	"uberspark-manifest": {
+		"manifest_node_types": [
+			"uberspark-bridge-cc"
+		],
+		"uberspark_min_version": "any",
+		"uberspark_max_version": "any"
 	},
-
-    "uberspark-bridge-cc" : {
+	"uberspark-bridge-cc": {
 		/* bridge header */
-	        "bridge-hdr":{
-		    "btype" : "container",
-		    "bname" : "compcert",
-		    "execname" : "ccomp",
-		    "devenv" : "amd64",
-		    "arch" : "x86_32",
-		    "cpu" : "generic",
-		    "version" : "v3.1",
-		    "path" : ".",
-		    "params" : [ "" ],
-		    "container_fname" : "uberspark_bridges.Dockerfile"
+		"bridge-hdr": {
+			"btype": "container",
+			"bname": "compcert",
+			"execname": "ccomp",
+			"devenv": "amd64",
+			"arch": "x86_32",
+			"cpu": "generic",
+			"version": "v3.1",
+			"path": ".",
+			"params": [
+				"-fpacked-structs",
+				"-fstruct-passing",
+				"-Wno-c11-extensions"
+			],
+			"container_fname": "uberspark_bridges.Dockerfile"
 		},
-
-	"params_prefix_obj" : "-c",
-        "params_prefix_asm" : "-S",
-        "params_prefix_output" : "-o",
-		"params_prefix_include" : "-I",
-		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
-
+		"params_prefix_obj": "-c",
+		"params_prefix_asm": "-S",
+		"params_prefix_output": "-o",
+		"params_prefix_include": "-I",
+		"params_cclib": "/usr/local/lib/compcert/libcompcert.a"
 	}
-
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.1/uberspark.json
@@ -29,7 +29,7 @@
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
 		"params_prefix_include" : "-I",
-		"params_cclib" : ""
+		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
 
 	}
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark.json
@@ -1,36 +1,37 @@
 /*
     uberSpark code bridges json definition
 */
-
 {
-   	/* manifest header */
-	   "uberspark-manifest":{
-		"manifest_node_types" : [ "uberspark-bridge-cc" ],
-		"uberspark_min_version" : "any",
-		"uberspark_max_version" : "any"
+	/* manifest header */
+	"uberspark-manifest": {
+		"manifest_node_types": [
+			"uberspark-bridge-cc"
+		],
+		"uberspark_min_version": "any",
+		"uberspark_max_version": "any"
 	},
-
-    "uberspark-bridge-cc" : {
+	"uberspark-bridge-cc": {
 		/* bridge header */
-		"bridge-hdr":{
-			"btype" : "container",
-			"bname" : "compcert",
-			"execname" : "ccomp",
-			"devenv" : "amd64",
-			"arch" : "x86_32",
-			"cpu" : "generic",
-			"version" : "v3.2",
-			"path" : ".",
-			"params" : [ "" ],
-			"container_fname" : "uberspark_bridges.Dockerfile"
+		"bridge-hdr": {
+			"btype": "container",
+			"bname": "compcert",
+			"execname": "ccomp",
+			"devenv": "amd64",
+			"arch": "x86_32",
+			"cpu": "generic",
+			"version": "v3.2",
+			"path": ".",
+			"params": [
+				"-fpacked-structs",
+				"-fstruct-passing",
+				"-Wno-c11-extensions"
+			],
+			"container_fname": "uberspark_bridges.Dockerfile"
 		},
-
-	"params_prefix_obj" : "-c",
-        "params_prefix_asm" : "-S",
-        "params_prefix_output" : "-o",
-		"params_prefix_include" : "-I",
-		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
-
+		"params_prefix_obj": "-c",
+		"params_prefix_asm": "-S",
+		"params_prefix_output": "-o",
+		"params_prefix_include": "-I",
+		"params_cclib": "/usr/local/lib/compcert/libcompcert.a"
 	}
-
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.2/uberspark.json
@@ -29,7 +29,7 @@
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
 		"params_prefix_include" : "-I",
-		"params_cclib" : ""
+		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
 
 	}
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/uberspark.json
@@ -1,36 +1,37 @@
 /*
     uberSpark code bridges json definition
 */
-
 {
-   	/* manifest header */
-	   "uberspark-manifest":{
-		"manifest_node_types" : [ "uberspark-bridge-cc" ],
-		"uberspark_min_version" : "any",
-		"uberspark_max_version" : "any"
+	/* manifest header */
+	"uberspark-manifest": {
+		"manifest_node_types": [
+			"uberspark-bridge-cc"
+		],
+		"uberspark_min_version": "any",
+		"uberspark_max_version": "any"
 	},
-
-    "uberspark-bridge-cc" : {
+	"uberspark-bridge-cc": {
 		/* bridge header */
-		"bridge-hdr":{
-			"btype" : "container",
-			"bname" : "compcert",
-			"execname" : "ccomp",
-			"devenv" : "amd64",
-			"arch" : "x86_32",
-			"cpu" : "generic",
-			"version" : "v3.3",
-			"path" : ".",
-			"params" : [ "" ],
-			"container_fname" : "uberspark_bridges.Dockerfile"
+		"bridge-hdr": {
+			"btype": "container",
+			"bname": "compcert",
+			"execname": "ccomp",
+			"devenv": "amd64",
+			"arch": "x86_32",
+			"cpu": "generic",
+			"version": "v3.3",
+			"path": ".",
+			"params": [
+				"-fpacked-structs",
+				"-fstruct-passing",
+				"-Wno-c11-extensions"
+			],
+			"container_fname": "uberspark_bridges.Dockerfile"
 		},
-
-	"params_prefix_obj" : "-c",
-        "params_prefix_asm" : "-S",
-        "params_prefix_output" : "-o",
-		"params_prefix_include" : "-I",
-		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
-
+		"params_prefix_obj": "-c",
+		"params_prefix_asm": "-S",
+		"params_prefix_output": "-o",
+		"params_prefix_include": "-I",
+		"params_cclib": "/usr/local/lib/compcert/libcompcert.a"
 	}
-
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.3/uberspark.json
@@ -29,7 +29,7 @@
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
 		"params_prefix_include" : "-I",
-		"params_cclib" : ""
+		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
 
 	}
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/uberspark.json
@@ -29,7 +29,7 @@
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
 		"params_prefix_include" : "-I",
-		"params_cclib" : ""
+		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
 
 	}
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.4/uberspark.json
@@ -1,36 +1,37 @@
 /*
     uberSpark code bridges json definition
 */
-
 {
-   	/* manifest header */
-	   "uberspark-manifest":{
-		"manifest_node_types" : [ "uberspark-bridge-cc" ],
-		"uberspark_min_version" : "any",
-		"uberspark_max_version" : "any"
+	/* manifest header */
+	"uberspark-manifest": {
+		"manifest_node_types": [
+			"uberspark-bridge-cc"
+		],
+		"uberspark_min_version": "any",
+		"uberspark_max_version": "any"
 	},
-
-    "uberspark-bridge-cc" : {
+	"uberspark-bridge-cc": {
 		/* bridge header */
-		"bridge-hdr":{
-			"btype" : "container",
-			"bname" : "compcert",
-			"execname" : "ccomp",
-			"devenv" : "amd64",
-			"arch" : "x86_32",
-			"cpu" : "generic",
-			"version" : "v3.4",
-			"path" : ".",
-			"params" : [ "" ],
-			"container_fname" : "uberspark_bridges.Dockerfile"
+		"bridge-hdr": {
+			"btype": "container",
+			"bname": "compcert",
+			"execname": "ccomp",
+			"devenv": "amd64",
+			"arch": "x86_32",
+			"cpu": "generic",
+			"version": "v3.4",
+			"path": ".",
+			"params": [
+				"-fpacked-structs",
+				"-fstruct-passing",
+				"-Wno-c11-extensions"
+			],
+			"container_fname": "uberspark_bridges.Dockerfile"
 		},
-
-	"params_prefix_obj" : "-c",
-        "params_prefix_asm" : "-S",
-        "params_prefix_output" : "-o",
-		"params_prefix_include" : "-I",
-		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
-
+		"params_prefix_obj": "-c",
+		"params_prefix_asm": "-S",
+		"params_prefix_output": "-o",
+		"params_prefix_include": "-I",
+		"params_cclib": "/usr/local/lib/compcert/libcompcert.a"
 	}
-
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/uberspark.json
@@ -29,7 +29,7 @@
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
 		"params_prefix_include" : "-I",
-		"params_cclib" : ""
+		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
 
 	}
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.5/uberspark.json
@@ -1,36 +1,37 @@
 /*
     uberSpark code bridges json definition
 */
-
 {
-   	/* manifest header */
-	   "uberspark-manifest":{
-		"manifest_node_types" : [ "uberspark-bridge-cc" ],
-		"uberspark_min_version" : "any",
-		"uberspark_max_version" : "any"
+	/* manifest header */
+	"uberspark-manifest": {
+		"manifest_node_types": [
+			"uberspark-bridge-cc"
+		],
+		"uberspark_min_version": "any",
+		"uberspark_max_version": "any"
 	},
-
-    "uberspark-bridge-cc" : {
+	"uberspark-bridge-cc": {
 		/* bridge header */
-		"bridge-hdr":{
-			"btype" : "container",
-			"bname" : "compcert",
-			"execname" : "ccomp",
-			"devenv" : "amd64",
-			"arch" : "x86_32",
-			"cpu" : "generic",
-			"version" : "v3.5",
-			"path" : ".",
-			"params" : [ "" ],
-			"container_fname" : "uberspark_bridges.Dockerfile"
+		"bridge-hdr": {
+			"btype": "container",
+			"bname": "compcert",
+			"execname": "ccomp",
+			"devenv": "amd64",
+			"arch": "x86_32",
+			"cpu": "generic",
+			"version": "v3.5",
+			"path": ".",
+			"params": [
+				"-fpacked-structs",
+				"-fstruct-passing",
+				"-Wno-c11-extensions"
+			],
+			"container_fname": "uberspark_bridges.Dockerfile"
 		},
-
-	"params_prefix_obj" : "-c",
-        "params_prefix_asm" : "-S",
-        "params_prefix_output" : "-o",
-		"params_prefix_include" : "-I",
-		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
-
+		"params_prefix_obj": "-c",
+		"params_prefix_asm": "-S",
+		"params_prefix_output": "-o",
+		"params_prefix_include": "-I",
+		"params_cclib": "/usr/local/lib/compcert/libcompcert.a"
 	}
-
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/uberspark.json
@@ -1,36 +1,37 @@
 /*
     uberSpark code bridges json definition
 */
-
 {
-   	/* manifest header */
-	   "uberspark-manifest":{
-		"manifest_node_types" : [ "uberspark-bridge-cc" ],
-		"uberspark_min_version" : "any",
-		"uberspark_max_version" : "any"
+	/* manifest header */
+	"uberspark-manifest": {
+		"manifest_node_types": [
+			"uberspark-bridge-cc"
+		],
+		"uberspark_min_version": "any",
+		"uberspark_max_version": "any"
 	},
-
-    "uberspark-bridge-cc" : {
+	"uberspark-bridge-cc": {
 		/* bridge header */
-		"bridge-hdr":{
-			"btype" : "container",
-			"bname" : "compcert",
-			"execname" : "ccomp",
-			"devenv" : "amd64",
-			"arch" : "x86_32",
-			"cpu" : "generic",
-			"version" : "v3.6",
-			"path" : ".",
-			"params" : [ "" ],
-			"container_fname" : "uberspark_bridges.Dockerfile"
+		"bridge-hdr": {
+			"btype": "container",
+			"bname": "compcert",
+			"execname": "ccomp",
+			"devenv": "amd64",
+			"arch": "x86_32",
+			"cpu": "generic",
+			"version": "v3.6",
+			"path": ".",
+			"params": [
+				"-fpacked-structs",
+				"-fstruct-passing",
+				"-Wno-c11-extensions"
+			],
+			"container_fname": "uberspark_bridges.Dockerfile"
 		},
-
-	"params_prefix_obj" : "-c",
-        "params_prefix_asm" : "-S",
-        "params_prefix_output" : "-o",
-		"params_prefix_include" : "-I",
-		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
-
+		"params_prefix_obj": "-c",
+		"params_prefix_asm": "-S",
+		"params_prefix_output": "-o",
+		"params_prefix_include": "-I",
+		"params_cclib": "/usr/local/lib/compcert/libcompcert.a"
 	}
-
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.6/uberspark.json
@@ -29,7 +29,7 @@
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
 		"params_prefix_include" : "-I",
-		"params_cclib" : ""
+		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
 
 	}
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/uberspark.json
@@ -29,7 +29,7 @@
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
 		"params_prefix_include" : "-I",
-		"params_cclib" : ""
+		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
 
 	}
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/compcert/v3.7/uberspark.json
@@ -1,36 +1,37 @@
 /*
     uberSpark code bridges json definition
 */
-
 {
-   	/* manifest header */
-	   "uberspark-manifest":{
-		"manifest_node_types" : [ "uberspark-bridge-cc" ],
-		"uberspark_min_version" : "any",
-		"uberspark_max_version" : "any"
+	/* manifest header */
+	"uberspark-manifest": {
+		"manifest_node_types": [
+			"uberspark-bridge-cc"
+		],
+		"uberspark_min_version": "any",
+		"uberspark_max_version": "any"
 	},
-
-    "uberspark-bridge-cc" : {
+	"uberspark-bridge-cc": {
 		/* bridge header */
-		"bridge-hdr":{
-			"btype" : "container",
-			"bname" : "compcert",
-			"execname" : "ccomp",
-			"devenv" : "amd64",
-			"arch" : "x86_32",
-			"cpu" : "generic",
-			"version" : "v3.7",
-			"path" : ".",
-			"params" : [ "" ],
-			"container_fname" : "uberspark_bridges.Dockerfile"
+		"bridge-hdr": {
+			"btype": "container",
+			"bname": "compcert",
+			"execname": "ccomp",
+			"devenv": "amd64",
+			"arch": "x86_32",
+			"cpu": "generic",
+			"version": "v3.7",
+			"path": ".",
+			"params": [
+				"-fpacked-structs",
+				"-fstruct-passing",
+				"-Wno-c11-extensions"
+			],
+			"container_fname": "uberspark_bridges.Dockerfile"
 		},
-
-	"params_prefix_obj" : "-c",
-        "params_prefix_asm" : "-S",
-        "params_prefix_output" : "-o",
-		"params_prefix_include" : "-I",
-		"params_cclib" : "/usr/local/lib/compcert/libcompcert.a"
-
+		"params_prefix_obj": "-c",
+		"params_prefix_asm": "-S",
+		"params_prefix_output": "-o",
+		"params_prefix_include": "-I",
+		"params_cclib": "/usr/local/lib/compcert/libcompcert.a"
 	}
-
 }

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/gcc/v5.4.0/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/gcc/v5.4.0/uberspark.json
@@ -35,7 +35,7 @@
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
 		"params_prefix_include" : "-I",
-		"params_cclib" : "/usr/lib/gcc/x86_64-linux-gnu/5/libgcc.a"
+		"params_cclib" : "/usr/lib/gcc/x86_64-linux-gnu/5/32/libgcc.a"
 
 	}
 

--- a/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/gcc/v5.5.0/uberspark.json
+++ b/src-nextgen/bridges/cc-bridge/container/amd64/x86_32/generic/gcc/v5.5.0/uberspark.json
@@ -35,7 +35,7 @@
         "params_prefix_asm" : "-S",
         "params_prefix_output" : "-o",
 		"params_prefix_include" : "-I",
-		"params_cclib" : "/usr/lib/gcc/x86_64-linux-gnu/5/libgcc.a"
+		"params_cclib" : "/usr/lib/gcc/x86_64-linux-gnu/5/32/libgcc.a"
 
 	}
 

--- a/src-nextgen/tools/libs/uberspark_codegen_uobj.ml
+++ b/src-nextgen/tools/libs/uberspark_codegen_uobj.ml
@@ -232,7 +232,22 @@ let generate_src_intrauobjcoll_callees_info
                 slt_ordinal := !slt_ordinal + 1;
             ) value;
         ) intrauobjcoll_callees_hashtbl;
-    
+
+        (* add terminating record *)
+            Printf.fprintf oc "\n\t{"; 
+            
+            (* namespace *)
+            Printf.fprintf oc "\n\t\t\"NULL\"," ; 
+            
+            (* cname *)
+            Printf.fprintf oc "\n\t\t\"NULL\"," ; 
+            
+            (* slt_ordinal *)
+            Printf.fprintf oc "\n\t0xFFFFFFFFUL";
+            
+            Printf.fprintf oc "\n\t}"; 
+
+
     Printf.fprintf oc "\n};";
 
     (* generate epilogue *)
@@ -280,6 +295,8 @@ let generate_src_interuobjcoll_callees_info
     Printf.fprintf oc "\n__attribute__(( section(\".uobj_interuobjcoll_cinfo\") )) usbinformat_uobj_callee_info_t uobj_interuobjcoll_callee_info [] = {";
 
         let slt_ordinal = ref 0 in
+        
+      
         Hashtbl.iter (fun key value ->  
             List.iter (fun pm_name -> 
                 Printf.fprintf oc "\n\t{"; 
@@ -297,7 +314,22 @@ let generate_src_interuobjcoll_callees_info
                 slt_ordinal := !slt_ordinal + 1;
             ) value;
         ) interuobjcoll_callees_hashtbl;
-    
+
+        (* add terminating record *)
+            Printf.fprintf oc "\n\t{"; 
+            
+            (* namespace *)
+            Printf.fprintf oc "\n\t\t\"NULL\"," ; 
+            
+            (* cname *)
+            Printf.fprintf oc "\n\t\t\"NULL\"," ; 
+            
+            (* slt_ordinal *)
+            Printf.fprintf oc "\n\t0xFFFFFFFFUL";
+            
+            Printf.fprintf oc "\n\t}"; 
+
+
     Printf.fprintf oc "\n};";
 
     (* generate epilogue *)
@@ -355,6 +387,9 @@ let generate_src_legacy_callees_info
     Printf.fprintf oc "\n__attribute__(( section(\".uobj_legacy_cinfo\") )) usbinformat_uobj_callee_info_t uobj_legacy_callees [] = {";
 
     let slt_ordinal = ref 0 in
+
+
+     
     Hashtbl.iter (fun key value ->
         List.iter (fun callee_name ->  
             Printf.fprintf oc "\n\t{"; 
@@ -370,6 +405,22 @@ let generate_src_legacy_callees_info
             slt_ordinal := !slt_ordinal + 1;
         ) value;
     )legacy_callees_hashtbl;
+
+
+        (* add terminating record *)
+            Printf.fprintf oc "\n\t{"; 
+            
+            (* namespace *)
+            Printf.fprintf oc "\n\t\t\"NULL\"," ; 
+            
+            (* cname *)
+            Printf.fprintf oc "\n\t\t\"NULL\"," ; 
+            
+            (* slt_ordinal *)
+            Printf.fprintf oc "\n\t0xFFFFFFFFUL";
+            
+            Printf.fprintf oc "\n\t}"; 
+
 
     Printf.fprintf oc "\n};";
 


### PR DESCRIPTION
fix(bridges/cc-bridge): revise container/amd64/x86_32/generic/compcert/v3.x to use libcompcert.a during linking phase
fix(bridges/cc-bridge): revise container/amd64/x86_32/generic/gcc/v5.4.0 and container/amd64/x86_32/generic/gcc/v5.5.0 to use 32-bit libgcc.a
refactor(tools/libs): revise uberspark.codegen.uobj to generate initialized struct  definitions for inter/intra uobj callees and legacy calles info